### PR TITLE
[BUGFIX] Move surf executable and fix autoload include

### DIFF
--- a/bin/surf
+++ b/bin/surf
@@ -1,8 +1,0 @@
-#!/usr/bin/env php
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';
-
-$app = new \TYPO3\Surf\Cli\Symfony\ConsoleApplication('TYPO3 Surf', '2.0.0-alpha1');
-$app->setFactory(new \TYPO3\Surf\Integration\Factory());
-$app->run();

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,7 @@
             "TYPO3\\Surf\\Tests\\": "Tests"
         }
     },
-    "bin": ["bin/surf"]
+    "bin": [
+        "surf"
+    ]
 }

--- a/surf
+++ b/surf
@@ -1,0 +1,14 @@
+#!/usr/bin/env php
+<?php
+
+foreach ([__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php'] as $file) {
+    if (file_exists($file)) {
+        /** @noinspection PhpIncludeInspection */
+        require $file;
+        break;
+    }
+}
+
+$app = new \TYPO3\Surf\Cli\Symfony\ConsoleApplication('TYPO3 Surf', '2.0.0-alpha1');
+$app->setFactory(new \TYPO3\Surf\Integration\Factory());
+$app->run();


### PR DESCRIPTION
The surf executable is moved to the root directory and a loop
is used for detecting the correct autoload.php file (inspired
by the concept used of phpunit).

Resolves: #8