### PR TITLE
[BUGFIX] Application specific directory and symlink options

### DIFF
--- a/src/Application/BaseApplication.php
+++ b/src/Application/BaseApplication.php
@@ -76,16 +76,8 @@ class BaseApplication extends \TYPO3\Surf\Domain\Model\Application
      */
     public function registerTasks(Workflow $workflow, Deployment $deployment)
     {
-        $workflow->setTaskOptions(
-            'TYPO3\\Surf\\Task\\Generic\\CreateDirectoriesTask',
-            array(
-                'directories' => $this->getDirectories()
-            ));
-        $workflow->setTaskOptions(
-            'TYPO3\\Surf\\Task\\Generic\\CreateSymlinksTask',
-            array(
-                'symlinks' => $this->getSymlinks()
-            ));
+        $this->setOption('TYPO3\\Surf\\Task\\Generic\\CreateDirectoriesTask[directories]', $this->getDirectories());
+        $this->setOption('TYPO3\\Surf\\Task\\Generic\\CreateSymlinksTask[symlinks]', $this->getSymlinks());
 
         if ($this->hasOption('packageMethod')) {
             $this->registerTasksForPackageMethod($workflow, $this->getOption('packageMethod'));


### PR DESCRIPTION
The options for the CreateDirectoriesTask and the
CreateSymlinksTask are now set as application options
in the registerTasks() call of the BaseApplication.

This makes sure that multiple applications do not override
the settings which can lead to unexpected behavior.