### PR TITLE
[BUGFIX] Fix creating shared/Data directories in Flow application

### DIFF
--- a/Tests/Unit/Task/Generic/CreateDirectoriesTaskTest.php
+++ b/Tests/Unit/Task/Generic/CreateDirectoriesTaskTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace TYPO3\Surf\Tests\Unit\Task\Generic;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 project "TYPO3 Surf".                 *
+ *                                                                        *
+ *                                                                        */
+
+use TYPO3\Surf\Task\Generic\CreateDirectoriesTask;
+use TYPO3\Surf\Tests\Unit\Task\BaseTaskTest;
+
+/**
+ * Class CreateDirectoriesTaskTest
+ */
+class CreateDirectoriesTaskTest extends BaseTaskTest
+{
+
+    /**
+     * @var CreateDirectoriesTask
+     */
+    protected $task;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->application = new \TYPO3\Surf\Application\TYPO3\CMS('TestApplication');
+        $this->application->setDeploymentPath('/home/jdoe/app');
+    }
+
+    /**
+     * @return CreateDirectoriesTask
+     */
+    protected function createTask()
+    {
+        return new CreateDirectoriesTask();
+    }
+
+    /**
+     * @test
+     */
+    public function createsDirectoriesInReleasePath()
+    {
+        $options = array('directories' => array('media'));
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+
+        $this->assertCommandExecuted("cd {$this->deployment->getApplicationReleasePath($this->application)}");
+        $this->assertCommandExecuted('mkdir -p media');
+    }
+
+    /**
+     * @test
+     */
+    public function createsDirectoriesInCustomPath()
+    {
+        $options = array('directories' => array('media'), 'baseDirectory' => '/foo/bar');
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+
+        $this->assertCommandExecuted('cd /foo/bar');
+        $this->assertCommandExecuted('mkdir -p media');
+    }
+}

--- a/Tests/Unit/Task/TYPO3/Flow/CreateDirectoriesTaskTest.php
+++ b/Tests/Unit/Task/TYPO3/Flow/CreateDirectoriesTaskTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace TYPO3\Surf\Tests\Unit\Task\TYPO3\Flow;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 project "TYPO3 Surf".                 *
+ *                                                                        *
+ *                                                                        */
+
+use TYPO3\Surf\Task\TYPO3\Flow\CreateDirectoriesTask;
+use TYPO3\Surf\Tests\Unit\Task\BaseTaskTest;
+
+/**
+ * Class CreateDirectoriesTaskTest
+ */
+class CreateDirectoriesTaskTest extends BaseTaskTest
+{
+
+    /**
+     * @var CreateDirectoriesTask
+     */
+    protected $task;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->application = new \TYPO3\Surf\Application\TYPO3\CMS('TestApplication');
+        $this->application->setDeploymentPath('/home/jdoe/app');
+    }
+
+    /**
+     * @return CreateDirectoriesTask
+     */
+    protected function createTask()
+    {
+        return new CreateDirectoriesTask();
+    }
+
+    /**
+     * @test
+     */
+    public function createsDirectoriesInDeploymentRoot()
+    {
+        $options = array();
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+
+        $this->assertCommandExecuted("cd {$this->application->getDeploymentPath()}");
+        $this->assertCommandExecuted('mkdir -p shared/Data/Logs');
+        $this->assertCommandExecuted('mkdir -p shared/Data/Persistent');
+        $this->assertCommandExecuted('mkdir -p shared/Configuration');
+    }
+
+}

--- a/src/Task/Generic/CreateDirectoriesTask.php
+++ b/src/Task/Generic/CreateDirectoriesTask.php
@@ -32,8 +32,10 @@ class CreateDirectoriesTask extends \TYPO3\Surf\Domain\Model\Task implements \TY
             return;
         }
 
+        $baseDirectory = isset($options['baseDirectory']) ? $options['baseDirectory'] : $deployment->getApplicationReleasePath($application);
+
         $commands = array(
-            'cd ' . $deployment->getApplicationReleasePath($application)
+            'cd ' . $baseDirectory
         );
         foreach ($options['directories'] as $path) {
             $commands[] = 'mkdir -p ' . $path;

--- a/src/Task/TYPO3/Flow/CreateDirectoriesTask.php
+++ b/src/Task/TYPO3/Flow/CreateDirectoriesTask.php
@@ -32,7 +32,8 @@ class CreateDirectoriesTask extends \TYPO3\Surf\Task\Generic\CreateDirectoriesTa
                 'shared/Data/Logs',
                 'shared/Data/Persistent',
                 'shared/Configuration'
-            )
+            ),
+            'baseDirectory' => $application->getDeploymentPath()
         );
         parent::execute($node, $application, $deployment, $options);
     }


### PR DESCRIPTION
With commit 642f7c3 the base directory for creating these directories
changed from the deployment base to the release path, causing the
directories to be created in the wrong place.

This commit adds a new option to allow specifing a different base
directory and the flow task can then provide this with the deployment
base.

Related: #25