### PR TITLE
[TASK] Add characters parameter to generateString 

### DIFF
--- a/src/Task/Php/WebOpcacheResetCreateScriptTask.php
+++ b/src/Task/Php/WebOpcacheResetCreateScriptTask.php
@@ -41,8 +41,9 @@ class WebOpcacheResetCreateScriptTask extends \TYPO3\Surf\Domain\Model\Task impl
         if (!isset($options['scriptIdentifier'])) {
             // Generate random identifier
             $factory = new \RandomLib\Factory;
+            $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
             $generator = $factory->getMediumStrengthGenerator();
-            $scriptIdentifier = $generator->generateString(32);
+            $scriptIdentifier = $generator->generateString(32, $characters);
 
             // Store the script identifier as an application option
             $application->setOption('TYPO3\\Surf\\Task\\Php\\WebOpcacheResetExecuteTask[scriptIdentifier]', $scriptIdentifier);


### PR DESCRIPTION
because standard uses base64 charset which also includes `/` and this results in an error while creating the script. So you have to set a scriptIdentifier as an option in your deployment script which, I think, isn't necessary because this should be the default.