### PR TITLE
[BUGFIX] Allow TaskTests to fake shell responses

### DIFF
--- a/Tests/Unit/Task/BaseTaskTest.php
+++ b/Tests/Unit/Task/BaseTaskTest.php
@@ -71,7 +71,7 @@ abstract class BaseTaskTest extends \PHPUnit_Framework_TestCase
             }
             return '';
         }));
-        $shellCommandService->expects($this->any())->method('executeOrSimulate')->will($this->returnCallback(function ($command) use (&$commands, $responses) {
+        $shellCommandService->expects($this->any())->method('executeOrSimulate')->will($this->returnCallback(function ($command) use (&$commands, &$responses) {
             if (is_array($command)) {
                 $commands['executed'] = array_merge($commands['executed'], $command);
             } else {


### PR DESCRIPTION
Adding the missing ampersand makes all the difference. Otherwise the $responses array can not be modified in the test methods. 