### PR TITLE
[TASK] Let WebOpcacheResetExecuteTask throw an error

### DIFF
--- a/src/Task/Php/WebOpcacheResetExecuteTask.php
+++ b/src/Task/Php/WebOpcacheResetExecuteTask.php
@@ -40,7 +40,7 @@ class WebOpcacheResetExecuteTask extends \TYPO3\Surf\Domain\Model\Task
 
         $result = file_get_contents($scriptUrl);
         if ($result !== 'success') {
-            $deployment->getLogger()->warning('Executing PHP opcache reset script at "' . $scriptUrl . '" did not return expected result');
+            throw new \TYPO3\Surf\Exception\TaskExecutionException('WebOpcacheResetExecuteTask at "' . $scriptUrl . '" did not return expected result', 1471511860);
         }
     }
 }

--- a/src/Task/Php/WebOpcacheResetExecuteTask.php
+++ b/src/Task/Php/WebOpcacheResetExecuteTask.php
@@ -40,7 +40,11 @@ class WebOpcacheResetExecuteTask extends \TYPO3\Surf\Domain\Model\Task
 
         $result = file_get_contents($scriptUrl);
         if ($result !== 'success') {
-            throw new \TYPO3\Surf\Exception\TaskExecutionException('WebOpcacheResetExecuteTask at "' . $scriptUrl . '" did not return expected result', 1471511860);
+            if ($options['ErrorOnWebOpCacheResetExecuteTask']) {
+                throw new \TYPO3\Surf\Exception\TaskExecutionException('WebOpcacheResetExecuteTask at "' . $scriptUrl . '" did not return expected result', 1471511860);
+            } else {
+                $deployment->getLogger()->warning('Executing PHP opcache reset script at "' . $scriptUrl . '" did not return expected result');
+            }
         }
-    }
+   }
 }

--- a/src/Task/Php/WebOpcacheResetExecuteTask.php
+++ b/src/Task/Php/WebOpcacheResetExecuteTask.php
@@ -40,7 +40,7 @@ class WebOpcacheResetExecuteTask extends \TYPO3\Surf\Domain\Model\Task
 
         $result = file_get_contents($scriptUrl);
         if ($result !== 'success') {
-            if ($options['ErrorOnWebOpCacheResetExecuteTask']) {
+            if (isset($options['throwErrorOnWebOpCacheResetExecuteTask']) && $options['throwErrorOnWebOpCacheResetExecuteTask']) {
                 throw new \TYPO3\Surf\Exception\TaskExecutionException('WebOpcacheResetExecuteTask at "' . $scriptUrl . '" did not return expected result', 1471511860);
             } else {
                 $deployment->getLogger()->warning('Executing PHP opcache reset script at "' . $scriptUrl . '" did not return expected result');


### PR DESCRIPTION
to be able to rollback.

We had this problem in 2 of our projects now so I've thought it would be interesting for the world.
The warnings are often overseen by others and so you definitely notice that something went wrong.
