### PR TITLE
[!!!][TASK] Updates Flow default version to 3.0

### DIFF
--- a/src/Application/TYPO3/Flow.php
+++ b/src/Application/TYPO3/Flow.php
@@ -24,7 +24,7 @@ class Flow extends \TYPO3\Surf\Application\BaseApplication
      * The TYPO3 Flow major and minor version of this application
      * @var string
      */
-    protected $version = '2.0';
+    protected $version = '3.0';
 
     /**
      * Constructor


### PR DESCRIPTION
This is breaking because older projects which still use Flow 2.* have to change this setting.

Resolves: #43