### PR TITLE
[TASK] Update naming scheme for Flow/Neos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Some of the features of the Surf package:
 
 ## Installation
 
-Install the Surf package by importing the package to a TYPO3 Flow application:
+Install the Surf package by importing the package to a Neos Flow application:
 
 
 	composer require typo3/surf

--- a/Tests/Unit/Domain/Model/SimpleWorkflowTest.php
+++ b/Tests/Unit/Domain/Model/SimpleWorkflowTest.php
@@ -239,7 +239,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
                     array(
                         'task' => 'typo3.surf:test:setup',
                         'node' => 'flow-1.example.com',
-                        'application' => 'TYPO3 Flow Application',
+                        'application' => 'Neos Flow Application',
                         'deployment' => 'Test deployment',
                         'stage' => 'initialize',
                         'options' => array()
@@ -247,7 +247,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
                     array(
                         'task' => 'typo3.surf:test:setup',
                         'node' => 'flow-2.example.com',
-                        'application' => 'TYPO3 Flow Application',
+                        'application' => 'Neos Flow Application',
                         'deployment' => 'Test deployment',
                         'stage' => 'initialize',
                         'options' => array()
@@ -263,7 +263,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
                     array(
                         'task' => 'typo3.surf:test:doctrine:migrate',
                         'node' => 'flow-1.example.com',
-                        'application' => 'TYPO3 Flow Application',
+                        'application' => 'Neos Flow Application',
                         'deployment' => 'Test deployment',
                         'stage' => 'migrate',
                         'options' => array()
@@ -271,7 +271,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
                     array(
                         'task' => 'typo3.surf:test:doctrine:migrate',
                         'node' => 'flow-2.example.com',
-                        'application' => 'TYPO3 Flow Application',
+                        'application' => 'Neos Flow Application',
                         'deployment' => 'Test deployment',
                         'stage' => 'migrate',
                         'options' => array()
@@ -303,7 +303,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
         $deployment = $this->buildDeployment($executedTasks);
         $workflow = $deployment->getWorkflow();
 
-        $flowApplication = new Application('TYPO3 Flow Application');
+        $flowApplication = new Application('Neos Flow Application');
         $flowApplication
             ->addNode(new Node('flow-1.example.com'))
             ->addNode(new Node('flow-2.example.com'));
@@ -359,7 +359,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
         $deployment = $this->buildDeployment($executedTasks);
         $workflow = $deployment->getWorkflow();
 
-        $flowApplication = new Application('TYPO3 Flow Application');
+        $flowApplication = new Application('Neos Flow Application');
         $flowApplication->addNode(new Node('flow-1.example.com'));
 
         $deployment->addApplication($flowApplication);
@@ -386,7 +386,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
             array(
                 'task' => 'before1:initialize',
                 'node' => 'flow-1.example.com',
-                'application' => 'TYPO3 Flow Application',
+                'application' => 'Neos Flow Application',
                 'deployment' => 'Test deployment',
                 'stage' => 'initialize',
                 'options' => array()
@@ -394,7 +394,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
             array(
                 'task' => 'before2:initialize',
                 'node' => 'flow-1.example.com',
-                'application' => 'TYPO3 Flow Application',
+                'application' => 'Neos Flow Application',
                 'deployment' => 'Test deployment',
                 'stage' => 'initialize',
                 'options' => array()
@@ -402,7 +402,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
             array(
                 'task' => 'before3:initialize',
                 'node' => 'flow-1.example.com',
-                'application' => 'TYPO3 Flow Application',
+                'application' => 'Neos Flow Application',
                 'deployment' => 'Test deployment',
                 'stage' => 'initialize',
                 'options' => array()
@@ -410,7 +410,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
             array(
                 'task' => 'task1:initialize',
                 'node' => 'flow-1.example.com',
-                'application' => 'TYPO3 Flow Application',
+                'application' => 'Neos Flow Application',
                 'deployment' => 'Test deployment',
                 'stage' => 'initialize',
                 'options' => array()
@@ -418,7 +418,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
             array(
                 'task' => 'task2:initialize',
                 'node' => 'flow-1.example.com',
-                'application' => 'TYPO3 Flow Application',
+                'application' => 'Neos Flow Application',
                 'deployment' => 'Test deployment',
                 'stage' => 'initialize',
                 'options' => array()
@@ -426,7 +426,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
             array(
                 'task' => 'task3:initialize',
                 'node' => 'flow-1.example.com',
-                'application' => 'TYPO3 Flow Application',
+                'application' => 'Neos Flow Application',
                 'deployment' => 'Test deployment',
                 'stage' => 'initialize',
                 'options' => array()
@@ -434,7 +434,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
             array(
                 'task' => 'after1:initialize',
                 'node' => 'flow-1.example.com',
-                'application' => 'TYPO3 Flow Application',
+                'application' => 'Neos Flow Application',
                 'deployment' => 'Test deployment',
                 'stage' => 'initialize',
                 'options' => array()
@@ -442,7 +442,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
             array(
                 'task' => 'after2:initialize',
                 'node' => 'flow-1.example.com',
-                'application' => 'TYPO3 Flow Application',
+                'application' => 'Neos Flow Application',
                 'deployment' => 'Test deployment',
                 'stage' => 'initialize',
                 'options' => array()
@@ -450,7 +450,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
             array(
                 'task' => 'after3:initialize',
                 'node' => 'flow-1.example.com',
-                'application' => 'TYPO3 Flow Application',
+                'application' => 'Neos Flow Application',
                 'deployment' => 'Test deployment',
                 'stage' => 'initialize',
                 'options' => array()
@@ -458,7 +458,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
             array(
                 'task' => 'task1:package',
                 'node' => 'flow-1.example.com',
-                'application' => 'TYPO3 Flow Application',
+                'application' => 'Neos Flow Application',
                 'deployment' => 'Test deployment',
                 'stage' => 'package',
                 'options' => array()
@@ -485,7 +485,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
                     array(
                         'task' => 'task2:package',
                         'node' => 'flow-1.example.com',
-                        'application' => 'TYPO3 Flow Application',
+                        'application' => 'Neos Flow Application',
                         'deployment' => 'Test deployment',
                         'stage' => 'package',
                         'options' => array()
@@ -504,7 +504,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
                     array(
                         'task' => 'task3:before',
                         'node' => 'flow-1.example.com',
-                        'application' => 'TYPO3 Flow Application',
+                        'application' => 'Neos Flow Application',
                         'deployment' => 'Test deployment',
                         'stage' => 'initialize',
                         'options' => array()
@@ -512,7 +512,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
                     array(
                         'task' => 'task1:initialize',
                         'node' => 'flow-1.example.com',
-                        'application' => 'TYPO3 Flow Application',
+                        'application' => 'Neos Flow Application',
                         'deployment' => 'Test deployment',
                         'stage' => 'initialize',
                         'options' => array()
@@ -531,7 +531,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
                     array(
                         'task' => 'task1:initialize',
                         'node' => 'flow-1.example.com',
-                        'application' => 'TYPO3 Flow Application',
+                        'application' => 'Neos Flow Application',
                         'deployment' => 'Test deployment',
                         'stage' => 'initialize',
                         'options' => array()
@@ -539,7 +539,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
                     array(
                         'task' => 'task3:after',
                         'node' => 'flow-1.example.com',
-                        'application' => 'TYPO3 Flow Application',
+                        'application' => 'Neos Flow Application',
                         'deployment' => 'Test deployment',
                         'stage' => 'initialize',
                         'options' => array()
@@ -559,7 +559,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
         $deployment = $this->buildDeployment($executedTasks);
         $workflow = $deployment->getWorkflow();
 
-        $flowApplication = new Application('TYPO3 Flow Application');
+        $flowApplication = new Application('Neos Flow Application');
         $flowApplication->addNode(new Node('flow-1.example.com'));
         $deployment->addApplication($flowApplication);
         $deployment->initialize();
@@ -586,7 +586,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
                     array(
                         'task' => 'task1:switch',
                         'node' => 'flow-1.example.com',
-                        'application' => 'TYPO3 Flow Application',
+                        'application' => 'Neos Flow Application',
                         'deployment' => 'Test deployment',
                         'stage' => 'switch',
                         'options' => array()
@@ -594,7 +594,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
                     array(
                         'task' => 'task2:afterSwitch',
                         'node' => 'flow-1.example.com',
-                        'application' => 'TYPO3 Flow Application',
+                        'application' => 'Neos Flow Application',
                         'deployment' => 'Test deployment',
                         'stage' => 'switch',
                         'options' => array()
@@ -614,7 +614,7 @@ class SimpleWorkflowTest extends \PHPUnit_Framework_TestCase
         $deployment = $this->buildDeployment($executedTasks);
         $workflow = $deployment->getWorkflow();
 
-        $flowApplication = new Application('TYPO3 Flow Application');
+        $flowApplication = new Application('Neos Flow Application');
         $flowApplication->addNode(new Node('flow-1.example.com'));
         $deployment->addApplication($flowApplication);
         $deployment->initialize();

--- a/src/Application/TYPO3/Flow.php
+++ b/src/Application/TYPO3/Flow.php
@@ -10,7 +10,7 @@ use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Workflow;
 
 /**
- * A TYPO3 Flow application template
+ * A Neos Flow application template
  */
 class Flow extends \TYPO3\Surf\Application\BaseApplication
 {
@@ -21,15 +21,16 @@ class Flow extends \TYPO3\Surf\Application\BaseApplication
     protected $context = 'Production';
 
     /**
-     * The TYPO3 Flow major and minor version of this application
+     * The Neos Flow major and minor version of this application
      * @var string
      */
     protected $version = '2.0';
 
     /**
      * Constructor
+     * @param string $name
      */
-    public function __construct($name = 'TYPO3_Flow')
+    public function __construct($name = 'Neos Flow')
     {
         parent::__construct($name);
         $this->options = array_merge($this->options, array(

--- a/src/Application/TYPO3/FlowDistribution.php
+++ b/src/Application/TYPO3/FlowDistribution.php
@@ -11,7 +11,7 @@ use TYPO3\Surf\Domain\Model\Workflow;
 use TYPO3\Surf\Exception\InvalidConfigurationException;
 
 /**
- * An "application" which does bundle Flow or similar distributions.
+ * An "application" which does bundle Neos Flow or similar distributions.
  *
  */
 class FlowDistribution extends \TYPO3\Surf\Application\TYPO3\Flow
@@ -26,7 +26,7 @@ class FlowDistribution extends \TYPO3\Surf\Application\TYPO3\Flow
      */
     public function __construct()
     {
-        parent::__construct('TYPO3 Flow Distribution');
+        parent::__construct('Neos Flow Distribution');
         $this->setOption('tagRecurseIntoSubmodules', true);
     }
 
@@ -91,7 +91,7 @@ class FlowDistribution extends \TYPO3\Surf\Application\TYPO3\Flow
             throw new InvalidConfigurationException('"version" option needs to be defined. Example: 1.0.0-beta2', 1314187396);
         }
         if (!$this->hasOption('projectName')) {
-            throw new InvalidConfigurationException('"projectName" option needs to be defined. Example: TYPO3 Flow', 1314187397);
+            throw new InvalidConfigurationException('"projectName" option needs to be defined. Example: Neos Flow', 1314187397);
         }
 
         if ($this->hasOption('enableSourceforgeUpload') && $this->getOption('enableSourceforgeUpload') === true) {

--- a/src/Application/TYPO3/Neos.php
+++ b/src/Application/TYPO3/Neos.php
@@ -10,7 +10,7 @@ use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Workflow;
 
 /**
- * A TYPO3 Neos application template
+ * A Neos application template
  *
  */
 class Neos extends \TYPO3\Surf\Application\TYPO3\Flow
@@ -18,7 +18,7 @@ class Neos extends \TYPO3\Surf\Application\TYPO3\Flow
     /**
      * Constructor
      */
-    public function __construct($name = 'TYPO3_Neos')
+    public function __construct($name = 'Neos')
     {
         parent::__construct($name);
     }

--- a/src/Task/TYPO3/CMS/RunCommandTask.php
+++ b/src/Task/TYPO3/CMS/RunCommandTask.php
@@ -12,7 +12,7 @@ use TYPO3\Surf\Domain\Model\Node;
 use TYPO3\Surf\Exception\InvalidConfigurationException;
 
 /**
- * Task for running arbitrary TYPO3 Flow commands
+ * Task for running arbitrary TYPO3 commands
  *
  */
 class RunCommandTask extends AbstractCliTask implements \TYPO3\Surf\Domain\Service\ShellCommandServiceAwareInterface

--- a/src/Task/TYPO3/Flow/CreateDirectoriesTask.php
+++ b/src/Task/TYPO3/Flow/CreateDirectoriesTask.php
@@ -11,7 +11,7 @@ use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Node;
 
 /**
- * A task to create TYPO3 Flow specific directories
+ * A task to create Neos Flow specific directories
  *
  */
 class CreateDirectoriesTask extends \TYPO3\Surf\Task\Generic\CreateDirectoriesTask

--- a/src/Task/TYPO3/Flow/FunctionalTestTask.php
+++ b/src/Task/TYPO3/Flow/FunctionalTestTask.php
@@ -11,7 +11,7 @@ use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Node;
 
 /**
- * A TYPO3 Flow task to run functional tests
+ * A Neos Flow task to run functional tests
  *
  */
 class FunctionalTestTask extends \TYPO3\Surf\Domain\Model\Task implements \TYPO3\Surf\Domain\Service\ShellCommandServiceAwareInterface

--- a/src/Task/TYPO3/Flow/MigrateTask.php
+++ b/src/Task/TYPO3/Flow/MigrateTask.php
@@ -11,7 +11,7 @@ use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Node;
 
 /**
- * A TYPO3 Flow migration task
+ * A Neos Flow migration task
  *
  */
 class MigrateTask extends \TYPO3\Surf\Domain\Model\Task implements \TYPO3\Surf\Domain\Service\ShellCommandServiceAwareInterface

--- a/src/Task/TYPO3/Flow/PublishResourcesTask.php
+++ b/src/Task/TYPO3/Flow/PublishResourcesTask.php
@@ -13,7 +13,7 @@ use TYPO3\Surf\Domain\Model\Task;
 use TYPO3\Surf\Exception\InvalidConfigurationException;
 
 /**
- * A TYPO3 Flow publish resources task
+ * A Neos Flow publish resources task
  */
 class PublishResourcesTask extends Task implements \TYPO3\Surf\Domain\Service\ShellCommandServiceAwareInterface
 {

--- a/src/Task/TYPO3/Flow/RunCommandTask.php
+++ b/src/Task/TYPO3/Flow/RunCommandTask.php
@@ -11,7 +11,7 @@ use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Node;
 
 /**
- * Task for running arbitrary TYPO3 Flow commands
+ * Task for running arbitrary Neos Flow commands
  *
  */
 class RunCommandTask extends \TYPO3\Surf\Domain\Model\Task implements \TYPO3\Surf\Domain\Service\ShellCommandServiceAwareInterface

--- a/src/Task/TYPO3/Flow/SetFilePermissionsTask.php
+++ b/src/Task/TYPO3/Flow/SetFilePermissionsTask.php
@@ -11,7 +11,7 @@ use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Node;
 
 /**
- * Task for setting file permissions for the TYPO3 Flow application
+ * Task for setting file permissions for the Neos Flow application
  */
 class SetFilePermissionsTask extends \TYPO3\Surf\Domain\Model\Task implements \TYPO3\Surf\Domain\Service\ShellCommandServiceAwareInterface
 {

--- a/src/Task/TYPO3/Flow/UnitTestTask.php
+++ b/src/Task/TYPO3/Flow/UnitTestTask.php
@@ -11,7 +11,7 @@ use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Node;
 
 /**
- * A TYPO3 Flow task to run unit tests
+ * A Neos Flow task to run unit tests
  *
  */
 class UnitTestTask extends \TYPO3\Surf\Domain\Model\Task implements \TYPO3\Surf\Domain\Service\ShellCommandServiceAwareInterface

--- a/src/Task/TYPO3/Neos/ImportSiteTask.php
+++ b/src/Task/TYPO3/Neos/ImportSiteTask.php
@@ -11,7 +11,7 @@ use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Node;
 
 /**
- * Task for importing content into TYPO3
+ * Task for importing content into Neos
  *
  */
 class ImportSiteTask extends \TYPO3\Surf\Domain\Model\Task implements \TYPO3\Surf\Domain\Service\ShellCommandServiceAwareInterface


### PR DESCRIPTION
Removes the TYPO3 family prefix and uses the guideline
for the Neos family.