### PR TITLE
FIX: No exception when describing non-scalar options

### DIFF
--- a/src/Command/DescribeCommand.php
+++ b/src/Command/DescribeCommand.php
@@ -66,7 +66,8 @@ class DescribeCommand extends Command implements FactoryAwareInterface
             $output->writeln('    Deployment path: ' . $application->getDeploymentPath());
             $output->writeln('    Options: ');
             foreach ($application->getOptions() as $key => $value) {
-                $output->writeln('      ' . $key . ' => ' . $value);
+                $printableValue = is_scalar($value) ? $value : gettype($value);
+                $output->writeln('      ' . $key . ' => ' . $printableValue);
             }
             $output->writeln('    Nodes: ' . implode(', ', $application->getNodes()));
         }


### PR DESCRIPTION
Previously the describe command threw and exception when printing
the value of ` TYPO3\Surf\Task\Generic\CreateDirectoriesTask[directories]`
or other options with array values.