### PR TITLE
Bugfix/runcommandtask

### DIFF
--- a/Tests/Unit/Task/TYPO3/CMS/RunCommandTaskTest.php
+++ b/Tests/Unit/Task/TYPO3/CMS/RunCommandTaskTest.php
@@ -3,11 +3,92 @@
 
 namespace TYPO3\Surf\Tests\Unit\Task\TYPO3\CMS;
 
+/*                                                                        *
+ * This script belongs to the TYPO3 project "TYPO3 Surf".                 *
+ *                                                                        *
+ *                                                                        */
+
 
 use TYPO3\Surf\Task\TYPO3\CMS\RunCommandTask;
+use TYPO3\Surf\Tests\Unit\Task\BaseTaskTest;
+use TYPO3\Surf\Application\TYPO3\CMS;
 
-
-class RunCommandTaskTest extends \PHPUnit_Framework_TestCase
+class RunCommandTaskTest extends BaseTaskTest
 {
+
+    /**
+     * @var RunCommandTask
+     */
+    protected $task;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->application = new CMS('TestApplication');
+    }
+
+    /**
+     * @test
+     * @expectedException \TYPO3\Surf\Exception\InvalidConfigurationException
+     */
+    public function exceptionThrownBecauseApplicationIsNotOfTypeCMS()
+    {
+        $wrongApplication = $this->getMockBuilder('TYPO3\Surf\Application\BaseApplication')->disableOriginalConstructor()->getMock();
+        $this->task->execute($this->node, $wrongApplication, $this->deployment);
+    }
+
+    /**
+     * @test
+     * @expectedException \TYPO3\Surf\Exception\InvalidConfigurationException
+     */
+    public function exceptionThrownBecauseNoCommandOptionDefined()
+    {
+        $this->task->execute($this->node, $this->application, $this->deployment, array());
+    }
+
+    /**
+     * @test
+     * @expectedException \TYPO3\Surf\Exception\InvalidConfigurationException
+     */
+    public function exceptionThrownBecauseNoScriptFileNameOptionDefined()
+    {
+        $this->task->execute($this->node, $this->application, $this->deployment, array('command' => 'command'));
+    }
+
+    /**
+     * @test
+     */
+    public function executeWithCommandAndScriptFileName()
+    {
+        $options = array(
+            'scriptFileName' => './typo3cms',
+            'command' => 'command:any',
+        );
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted("php './typo3cms' 'command:any'");
+    }
+
+    /**
+     * @test
+     */
+    public function executeWithCommandAndScriptFileNameAndArgument()
+    {
+        $options = array(
+            'scriptFileName' => './typo3cms',
+            'command' => 'command:any',
+            'arguments' => 'any',
+        );
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted("php './typo3cms' 'command:any' 'any'");
+    }
+
+    /**
+     * @return RunCommandTask
+     */
+    protected function createTask()
+    {
+        return new RunCommandTask();
+    }
+
 
 }

--- a/Tests/Unit/Task/TYPO3/CMS/RunCommandTaskTest.php
+++ b/Tests/Unit/Task/TYPO3/CMS/RunCommandTaskTest.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace TYPO3\Surf\Tests\Unit\Task\TYPO3\CMS;
+
+
+use TYPO3\Surf\Task\TYPO3\CMS\RunCommandTask;
+
+
+class RunCommandTaskTest extends \PHPUnit_Framework_TestCase
+{
+
+}

--- a/src/Task/TYPO3/CMS/RunCommandTask.php
+++ b/src/Task/TYPO3/CMS/RunCommandTask.php
@@ -37,6 +37,9 @@ class RunCommandTask extends AbstractCliTask
         if (!isset($options['command'])) {
             throw new InvalidConfigurationException('Missing option "command" for RunCommandTask', 1319201396);
         }
+        if(!isset($options['scriptFileName'])) {
+            throw new InvalidConfigurationException('Missing option "scriptFileName" for RunCommandTask', 1481489230);
+        }
         $this->executeCliCommand(
             $this->getArguments($options),
             $node,

--- a/src/Task/TYPO3/CMS/RunCommandTask.php
+++ b/src/Task/TYPO3/CMS/RunCommandTask.php
@@ -15,9 +15,8 @@ use TYPO3\Surf\Exception\InvalidConfigurationException;
  * Task for running arbitrary TYPO3 commands
  *
  */
-class RunCommandTask extends AbstractCliTask implements \TYPO3\Surf\Domain\Service\ShellCommandServiceAwareInterface
+class RunCommandTask extends AbstractCliTask
 {
-    use \TYPO3\Surf\Domain\Service\ShellCommandServiceAwareTrait;
 
     /**
      * Execute this task


### PR DESCRIPTION
1. Removed ShellCommandServiceAwareInterface and the ShellCommandServiceAwareTrait from RunCommandTask Class. Because these are already implemented in the parent class. 
2. Added a check if the option scriptFileName is configured, otherwise an InvalidConfigurationException is thrown. We need this option, so we have to check it first.
3. Added RunCommandTaskTest