### PR TITLE
Web opcache reset create script task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.surf
 .idea/
 
 vendor/

--- a/Tests/Unit/Task/Php/WebOpcacheResetTaskTest.php
+++ b/Tests/Unit/Task/Php/WebOpcacheResetTaskTest.php
@@ -55,7 +55,8 @@ class WebOpcacheResetTaskTest extends BaseTaskTest
         );
 
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
-        $this->assertCommandExecuted('/echo \'' .preg_quote(WebOpcacheResetTask::SCRIPT_CODE). '\' > \/home\/jdoe\/app\/releases\/[0-9]+\/Web\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-[a-zA-Z0-9]{32}/');
+        $pathToFile = '\/home\/jdoe\/app\/releases\/[0-9]+\/Web\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-[a-zA-Z0-9]{32}.php';
+        $this->assertCommandExecuted('/echo ' .escapeshellarg(preg_quote(WebOpcacheResetTask::SCRIPT_CODE)). ' > ' .escapeshellarg($pathToFile).'/');
     }
 
     /**
@@ -69,7 +70,8 @@ class WebOpcacheResetTaskTest extends BaseTaskTest
         );
 
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
-        $this->assertCommandExecuted('/echo \'' .preg_quote(WebOpcacheResetTask::SCRIPT_CODE). '\' > basepath\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-[a-zA-Z0-9]{32}/');
+        $pathToFile = 'basepath\/' .WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-[a-zA-Z0-9]{32}.php';
+        $this->assertCommandExecuted('/echo ' .escapeshellarg(preg_quote(WebOpcacheResetTask::SCRIPT_CODE)). ' > '.escapeshellarg($pathToFile).'/');
     }
 
     /**
@@ -84,7 +86,8 @@ class WebOpcacheResetTaskTest extends BaseTaskTest
         );
 
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
-        $this->assertCommandExecuted('/echo \'' .preg_quote(WebOpcacheResetTask::SCRIPT_CODE). '\' > \/home\/jdoe\/app\/releases\/[0-9]+\/Web\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-'.$identifier.'/');
+        $pathToFile = '\/home\/jdoe\/app\/releases\/[0-9]+\/Web\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-'.$identifier.'.php';
+        $this->assertCommandExecuted('/echo ' .escapeshellarg(preg_quote(WebOpcacheResetTask::SCRIPT_CODE)). ' > ' .escapeshellarg($pathToFile). '/');
     }
 
     /**
@@ -100,7 +103,8 @@ class WebOpcacheResetTaskTest extends BaseTaskTest
         );
 
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
-        $this->assertCommandExecuted('/echo \'' .preg_quote(WebOpcacheResetTask::SCRIPT_CODE). '\' > basepath\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-'.$identifier.'/');
+        $pathToFile = 'basepath\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-'.$identifier. '.php';
+        $this->assertCommandExecuted('/echo ' .escapeshellarg(preg_quote(WebOpcacheResetTask::SCRIPT_CODE)). ' > ' .escapeshellarg($pathToFile). '/');
     }
 
 

--- a/Tests/Unit/Task/Php/WebOpcacheResetTaskTest.php
+++ b/Tests/Unit/Task/Php/WebOpcacheResetTaskTest.php
@@ -55,7 +55,7 @@ class WebOpcacheResetTaskTest extends BaseTaskTest
         );
 
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
-        $pathToFile = '\/home\/jdoe\/app\/releases\/[0-9]+\/Web\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-[a-zA-Z0-9]{32}.php';
+        $pathToFile = '\/home\/jdoe\/app\/releases\/[0-9]+\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-[a-zA-Z0-9]{32}.php';
         $this->assertCommandExecuted('/echo ' .escapeshellarg(preg_quote(WebOpcacheResetTask::SCRIPT_CODE)). ' > ' .escapeshellarg($pathToFile).'/');
     }
 
@@ -86,7 +86,7 @@ class WebOpcacheResetTaskTest extends BaseTaskTest
         );
 
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
-        $pathToFile = '\/home\/jdoe\/app\/releases\/[0-9]+\/Web\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-'.$identifier.'.php';
+        $pathToFile = '\/home\/jdoe\/app\/releases\/[0-9]+\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-'.$identifier.'.php';
         $this->assertCommandExecuted('/echo ' .escapeshellarg(preg_quote(WebOpcacheResetTask::SCRIPT_CODE)). ' > ' .escapeshellarg($pathToFile). '/');
     }
 

--- a/Tests/Unit/Task/Php/WebOpcacheResetTaskTest.php
+++ b/Tests/Unit/Task/Php/WebOpcacheResetTaskTest.php
@@ -1,0 +1,119 @@
+<?php
+
+
+namespace TYPO3\Surf\Unit\Task\Php;
+
+
+use TYPO3\Surf\Task\Php\WebOpcacheResetTask;
+use TYPO3\Surf\Tests\Unit\Task\BaseTaskTest;
+
+class WebOpcacheResetTaskTest extends BaseTaskTest
+{
+
+    /**
+     * @var WebOpcacheResetTask|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $task;
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->task->expects($this->any())->method('executeScript')->willReturn('success');
+        $this->application->setDeploymentPath('/home/jdoe/app');
+    }
+
+    /**
+     * @test
+     */
+    public function executeInDryRunMode()
+    {
+        $this->deployment->setDryRun(true);
+        $this->task->execute($this->node, $this->application, $this->deployment);
+        $this->assertEmpty($this->commands['executed']);
+    }
+
+
+    /**
+     * @test
+     * @expectedException \TYPO3\Surf\Exception\InvalidConfigurationException
+     */
+    public function noBaseUrlOptionDefined()
+    {
+        $this->task->execute($this->node, $this->application, $this->deployment);
+    }
+
+    /**
+     * @test
+     */
+    public function executeWithOutScriptBasePathAndRandomScriptIdentifier()
+    {
+        $options = array(
+            'baseUrl' => 'http://domain.com/'
+        );
+
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted('/echo \'' .preg_quote(WebOpcacheResetTask::SCRIPT_CODE). '\' > \/home\/jdoe\/app\/releases\/[0-9]+\/Web\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-[a-zA-Z0-9]{32}/');
+    }
+
+    /**
+     * @test
+     */
+    public function executeWithScriptBasePathAndRandomScriptIdentifier()
+    {
+        $options = array(
+            'baseUrl' => 'http://domain.com/',
+            'scriptBasePath' => 'basepath'
+        );
+
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted('/echo \'' .preg_quote(WebOpcacheResetTask::SCRIPT_CODE). '\' > basepath\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-[a-zA-Z0-9]{32}/');
+    }
+
+    /**
+     * @test
+     */
+    public function executeWithOutScriptBasePathAndScriptIdentifier()
+    {
+        $identifier = 'identifier';
+        $options = array(
+            'baseUrl' => 'http://domain.com/',
+            'scriptIdentifier' => $identifier
+        );
+
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted('/echo \'' .preg_quote(WebOpcacheResetTask::SCRIPT_CODE). '\' > \/home\/jdoe\/app\/releases\/[0-9]+\/Web\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-'.$identifier.'/');
+    }
+
+    /**
+     * @test
+     */
+    public function executeWithScriptBasePathAndScriptIdentifier()
+    {
+        $identifier = 'identifier';
+        $options = array(
+            'baseUrl' => 'http://domain.com/',
+            'scriptIdentifier' => $identifier,
+            'scriptBasePath' => 'basepath'
+        );
+
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted('/echo \'' .preg_quote(WebOpcacheResetTask::SCRIPT_CODE). '\' > basepath\/'.WebOpcacheResetTask::DEFAULT_SCRIPT_PREFIX. '-'.$identifier.'/');
+    }
+
+
+
+    /**
+     * @return WebOpcacheResetTask
+     */
+    protected function createTask()
+    {
+        /** @var WebOpcacheResetTask|\PHPUnit_Framework_MockObject_MockObject $mockTask */
+        $mockTask = $this->getMock('TYPO3\\Surf\\Task\\Php\\WebOpcacheResetTask', array('executeScript'));
+        return $mockTask;
+    }
+
+
+}

--- a/src/Task/Php/WebOpcacheResetCreateScriptTask.php
+++ b/src/Task/Php/WebOpcacheResetCreateScriptTask.php
@@ -12,16 +12,10 @@ use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Node;
 
 /**
- * Create a script to reset the PHP opcache
- *
- * The task creates a temporary script (locally in the release workspace directory) for resetting the PHP opcache in a
- * later web request. A secondary task will execute an HTTP request and thus execute the script.
- *
- * The opcache reset has to be done in the webserver process, so a simple CLI command would not help.
+ * @deprecated Not needed anymore use WebOpcacheResetTask
  */
-class WebOpcacheResetCreateScriptTask extends \TYPO3\Surf\Domain\Model\Task implements \TYPO3\Surf\Domain\Service\ShellCommandServiceAwareInterface
+class WebOpcacheResetCreateScriptTask extends \TYPO3\Surf\Domain\Model\Task
 {
-    use \TYPO3\Surf\Domain\Service\ShellCommandServiceAwareTrait;
 
     /**
      * Execute this task
@@ -36,44 +30,6 @@ class WebOpcacheResetCreateScriptTask extends \TYPO3\Surf\Domain\Model\Task impl
      */
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = array())
     {
-        $workspacePath = $deployment->getWorkspacePath($application);
-        $scriptBasePath = isset($options['scriptBasePath']) ? $options['scriptBasePath'] : Files::concatenatePaths(array($workspacePath, 'Web'));
-
-        if (!isset($options['scriptIdentifier'])) {
-            // Generate random identifier
-            $factory = new \RandomLib\Factory;
-            $generator = $factory->getMediumStrengthGenerator();
-            $scriptIdentifier = $generator->generateString(32, \RandomLib\Generator::CHAR_ALNUM);
-
-            // Store the script identifier as an application option
-            $application->setOption('TYPO3\\Surf\\Task\\Php\\WebOpcacheResetExecuteTask[scriptIdentifier]', $scriptIdentifier);
-        } else {
-            $scriptIdentifier = $options['scriptIdentifier'];
-        }
-
-        $localhost = new Node('localhost');
-        $localhost->setHostname('localhost');
-
-        $commands = array(
-            'cd ' . escapeshellarg($scriptBasePath),
-            'rm -f surf-opcache-reset-*'
-        );
-
-        $this->shell->executeOrSimulate($commands, $localhost, $deployment);
-
-        if (!$deployment->isDryRun()) {
-            $scriptFilename = $scriptBasePath . '/surf-opcache-reset-' . $scriptIdentifier . '.php';
-            $result = file_put_contents($scriptFilename, '<?php
-                if (function_exists("opcache_reset")) {
-                    opcache_reset();
-                }
-                @unlink(__FILE__);
-                echo "success";
-            ');
-
-            if ($result === false) {
-                throw new \TYPO3\Surf\Exception\TaskExecutionException('Could not write file "' . $scriptFilename . '"', 1421932414);
-            }
-        }
+        $deployment->getLogger()->notice('This task is not needed anymore. Just use WebOpcacheResetTask');
     }
 }

--- a/src/Task/Php/WebOpcacheResetCreateScriptTask.php
+++ b/src/Task/Php/WebOpcacheResetCreateScriptTask.php
@@ -30,6 +30,6 @@ class WebOpcacheResetCreateScriptTask extends \TYPO3\Surf\Domain\Model\Task
      */
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = array())
     {
-        $deployment->getLogger()->notice('This task is not needed anymore. Just use WebOpcacheResetTask');
+        $deployment->getLogger()->warning('This task is not needed anymore. Just use WebOpcacheResetTask');
     }
 }

--- a/src/Task/Php/WebOpcacheResetExecuteTask.php
+++ b/src/Task/Php/WebOpcacheResetExecuteTask.php
@@ -11,9 +11,9 @@ use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Node;
 
 /**
- * A task to reset the PHP opcache by executing a prepared script with an HTTP request
+ * @deprecated Not needed anymore. Just use WebOpcacheResetTask directly
  */
-class WebOpcacheResetExecuteTask extends \TYPO3\Surf\Domain\Model\Task
+class WebOpcacheResetExecuteTask extends WebOpcacheResetTask
 {
     /**
      * Execute this task
@@ -28,19 +28,7 @@ class WebOpcacheResetExecuteTask extends \TYPO3\Surf\Domain\Model\Task
      */
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = array())
     {
-        if (!isset($options['baseUrl'])) {
-            throw new \TYPO3\Surf\Exception\InvalidConfigurationException('No "baseUrl" option provided for WebOpcacheResetExecuteTask', 1421932609);
-        }
-        if (!isset($options['scriptIdentifier'])) {
-            throw new \TYPO3\Surf\Exception\InvalidConfigurationException('No "scriptIdentifier" option provided for WebOpcacheResetExecuteTask, make sure to execute "TYPO3\\Surf\\Task\\Php\\WebOpcacheResetCreateScriptTask" before this task or pass one explicitly', 1421932610);
-        }
-
-        $scriptIdentifier = $options['scriptIdentifier'];
-        $scriptUrl = rtrim($options['baseUrl'], '/') . '/surf-opcache-reset-' . $scriptIdentifier . '.php';
-
-        $result = file_get_contents($scriptUrl);
-        if ($result !== 'success') {
-            $deployment->getLogger()->warning('Executing PHP opcache reset script at "' . $scriptUrl . '" did not return expected result');
-        }
+        parent::execute($node, $application, $deployment, $options);
+        $deployment->getLogger()->notice('This task is not needed anymore. Just use WebOpcacheResetTask directly');
     }
 }

--- a/src/Task/Php/WebOpcacheResetExecuteTask.php
+++ b/src/Task/Php/WebOpcacheResetExecuteTask.php
@@ -29,6 +29,6 @@ class WebOpcacheResetExecuteTask extends WebOpcacheResetTask
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = array())
     {
         parent::execute($node, $application, $deployment, $options);
-        $deployment->getLogger()->notice('This task is not needed anymore. Just use WebOpcacheResetTask directly');
+        $deployment->getLogger()->warning('This task is not needed anymore. Just use WebOpcacheResetTask directly');
     }
 }

--- a/src/Task/Php/WebOpcacheResetTask.php
+++ b/src/Task/Php/WebOpcacheResetTask.php
@@ -40,7 +40,7 @@ class WebOpcacheResetTask extends Task implements ShellCommandServiceAwareInterf
     /**
      * @var string
      */
-    const SCRIPT_CODE = '<?php if (function_exists("opcache_reset")) { opcache_reset(); } @unlink(__FILE__); echo "success"';
+    const SCRIPT_CODE = '<?php if (function_exists("opcache_reset")) { opcache_reset(); } @unlink(__FILE__); echo "success";';
 
     use ShellCommandServiceAwareTrait;
 
@@ -60,9 +60,11 @@ class WebOpcacheResetTask extends Task implements ShellCommandServiceAwareInterf
                     1421932609);
             }
 
+            // Defaults to Web in the CMS Application
+            $webDirectory = isset($options['webDirectory']) ? trim($options['webDirectory'], '\\/') : '';
             $basePath = isset($options['scriptBasePath']) ? $options['scriptBasePath'] : Files::concatenatePaths(array(
                 $deployment->getApplicationReleasePath($application),
-                'Web',
+                $webDirectory,
             ));
 
             $identifier = isset($options['scriptIdentifier']) ? $options['scriptIdentifier'] : $this->generateRandomIdentifier();

--- a/src/Task/Php/WebOpcacheResetTask.php
+++ b/src/Task/Php/WebOpcacheResetTask.php
@@ -67,7 +67,7 @@ class WebOpcacheResetTask extends Task implements ShellCommandServiceAwareInterf
 
             $identifier = isset($options['scriptIdentifier']) ? $options['scriptIdentifier'] : $this->generateRandomIdentifier();
             $filename = sprintf('%s-%s.php', self::DEFAULT_SCRIPT_PREFIX, $identifier);
-            $command = sprintf('echo \'%s\' > %s', self::SCRIPT_CODE, $basePath.'/'.$filename);
+            $command = sprintf('echo %s > %s', escapeshellarg(self::SCRIPT_CODE), escapeshellarg($basePath.'/'.$filename));
 
             $this->shell->execute($command, $node, $deployment);
 

--- a/src/Task/Php/WebOpcacheResetTask.php
+++ b/src/Task/Php/WebOpcacheResetTask.php
@@ -1,0 +1,102 @@
+<?php
+
+
+namespace TYPO3\Surf\Task\Php;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 project "TYPO3 Surf"                  *
+ *                                                                        *
+ *                                                                        */
+
+use RandomLib\Factory;
+use RandomLib\Generator;
+use TYPO3\Flow\Utility\Files;
+use TYPO3\Surf\Domain\Model\Application;
+use TYPO3\Surf\Domain\Model\Deployment;
+use TYPO3\Surf\Domain\Model\Node;
+use TYPO3\Surf\Domain\Model\Task;
+use TYPO3\Surf\Domain\Service\ShellCommandServiceAwareTrait;
+use TYPO3\Surf\Domain\Service\ShellCommandServiceAwareInterface;
+use TYPO3\Surf\Exception\InvalidConfigurationException;
+
+/**
+ * Create a script and execute it to reset the PHP opcache
+ *
+ * The opcache reset has to be done in the webserver process, so a simple CLI command would not help.
+ */
+class WebOpcacheResetTask extends Task implements ShellCommandServiceAwareInterface
+{
+
+    /**
+     * @var int
+     */
+    const DEFAULT_SCRIPT_IDENTIFIER_LENGTH = 32;
+
+    /**
+     * @var string
+     */
+    const DEFAULT_SCRIPT_PREFIX = 'surf-opcache-reset';
+
+    /**
+     * @var string
+     */
+    const SCRIPT_CODE = '<?php if (function_exists("opcache_reset")) { opcache_reset(); } @unlink(__FILE__); echo "success"';
+
+    use ShellCommandServiceAwareTrait;
+
+    /**
+     * @param Node $node
+     * @param Application $application
+     * @param Deployment $deployment
+     * @param array $options
+     *
+     * @throws InvalidConfigurationException
+     */
+    public function execute(Node $node, Application $application, Deployment $deployment, array $options = array())
+    {
+        if ( ! $deployment->isDryRun()) {
+            if ( ! isset($options['baseUrl'])) {
+                throw new InvalidConfigurationException('No "baseUrl" option provided for WebOpcacheResetTask',
+                    1421932609);
+            }
+
+            $basePath = isset($options['scriptBasePath']) ? $options['scriptBasePath'] : Files::concatenatePaths(array(
+                $deployment->getApplicationReleasePath($application),
+                'Web',
+            ));
+
+            $identifier = isset($options['scriptIdentifier']) ? $options['scriptIdentifier'] : $this->generateRandomIdentifier();
+            $filename = sprintf('%s-%s.php', self::DEFAULT_SCRIPT_PREFIX, $identifier);
+            $command = sprintf('echo \'%s\' > %s', self::SCRIPT_CODE, $basePath.'/'.$filename);
+
+            $this->shell->execute($command, $node, $deployment);
+
+            $url = rtrim($options['baseUrl'], '/').'/'.$filename;
+            if ($this->executeScript($url) !== 'success') {
+                $deployment->getLogger()->warning('Executing PHP opcache reset script at "'.$url.'" did not return expected result');
+            }
+        }
+    }
+
+    /**
+     * @return string
+     */
+    private function generateRandomIdentifier()
+    {
+        // Generate random identifier
+        $factory   = new Factory();
+        $generator = $factory->getMediumStrengthGenerator();
+
+        return $generator->generateString(self::DEFAULT_SCRIPT_IDENTIFIER_LENGTH, Generator::CHAR_ALNUM);
+    }
+
+    /**
+     * @param $url
+     *
+     * @return string
+     */
+    protected function executeScript($url)
+    {
+        return file_get_contents($url);
+    }
+}


### PR DESCRIPTION
Introduce new task WebOpcacheResetTask which creates the the script to reset opcache only on the remote server. Targeting the issue #21. 

The both task WebOpcacheResetCreateScriptTask and WebOpcacheResetExecuteTask marked as deprecated. 

The new WebOpcacheResetTask is not breaking anything. The old task WebOpcacheResetCreateScriptTask does nothing and the WebOpcacheResetExecuteTask extends WebOpcacheResetTask and delegates the command to it.