### PR TITLE
[FEATURE] Replace manifestPath in composerCommandPath

### DIFF
--- a/src/Task/Composer/InstallTask.php
+++ b/src/Task/Composer/InstallTask.php
@@ -73,9 +73,18 @@ class InstallTask extends \TYPO3\Surf\Domain\Model\Task implements \TYPO3\Surf\D
         if (!isset($options['composerCommandPath'])) {
             throw new \TYPO3\Surf\Exception\TaskExecutionException('Composer command not found. Set the composerCommandPath option.', 1349163257);
         }
+
+        $manifestPath = escapeshellarg($manifestPath);
+        $replacePaths = array(
+            '{manifestPath}' => $manifestPath,
+        );
+
+        $composer = $options['composerCommandPath'];
+        $composer = str_replace(array_keys($replacePaths), $replacePaths, $composer);
+
         return array(
-            'cd ' . escapeshellarg($manifestPath),
-            escapeshellcmd($options['composerCommandPath']) . ' install --no-ansi --no-interaction --no-dev --no-progress --classmap-authoritative 2>&1',
+            'cd ' . $manifestPath,
+            escapeshellcmd($composer) . ' install --no-ansi --no-interaction --no-dev --no-progress --classmap-authoritative 2>&1',
         );
     }
 


### PR DESCRIPTION
To use a docker based composer it is necessary to map the manifest path inside the container.
To achieve this and keep the security by escaping shell commands, the manifest path gets replaced inside the given composer command path.
E.g. set `docker run --rm -v {manifestPath}:/app composer` as composerCommandPath.
It’s now possible to use a composer docker container with the same PHP version, extensions and libraries as the live system
so not fulfilled platform requirements would fail on deployment, not on remote.

Resolves: #63