### PR TITLE
[TASK] Ensure symlinks in TYPO3 CMS projects are created in web directory

### DIFF
--- a/Tests/Unit/Task/TYPO3/CMS/SymlinkDataTaskTest.php
+++ b/Tests/Unit/Task/TYPO3/CMS/SymlinkDataTaskTest.php
@@ -47,6 +47,8 @@ class SymlinkDataTaskTest extends BaseTaskTest
         $this->assertCommandExecuted("cd '{$releasePath}'");
         $this->assertCommandExecuted("{ [ -d {$dataPath}/fileadmin ] || mkdir -p {$dataPath}/fileadmin ; }");
         $this->assertCommandExecuted("{ [ -d {$dataPath}/uploads ] || mkdir -p {$dataPath}/uploads ; }");
+        $this->assertCommandExecuted("rm -rf '{$releasePath}'/fileadmin");
+        $this->assertCommandExecuted("rm -rf '{$releasePath}'/uploads");
         $this->assertCommandExecuted("ln -sf {$dataPath}/fileadmin '{$releasePath}'/fileadmin");
         $this->assertCommandExecuted("ln -sf {$dataPath}/uploads '{$releasePath}'/uploads");
     }
@@ -66,6 +68,8 @@ class SymlinkDataTaskTest extends BaseTaskTest
         $this->assertCommandExecuted("cd '{$releasePath}'");
         $this->assertCommandExecuted("{ [ -d {$dataPath}/fileadmin ] || mkdir -p {$dataPath}/fileadmin ; }");
         $this->assertCommandExecuted("{ [ -d {$dataPath}/uploads ] || mkdir -p {$dataPath}/uploads ; }");
+        $this->assertCommandExecuted("rm -rf '{$releasePath}'/fileadmin");
+        $this->assertCommandExecuted("rm -rf '{$releasePath}'/uploads");
         $this->assertCommandExecuted("ln -sf {$dataPath}/fileadmin '{$releasePath}'/fileadmin");
         $this->assertCommandExecuted("ln -sf {$dataPath}/uploads '{$releasePath}'/uploads");
         $this->assertCommandExecuted("{ [ -d '{$dataPath}/pictures' ] || mkdir -p '{$dataPath}/pictures' ; }");
@@ -89,6 +93,8 @@ class SymlinkDataTaskTest extends BaseTaskTest
         $this->assertCommandExecuted("cd '{$releasePath}'");
         $this->assertCommandExecuted("{ [ -d {$dataPath}/fileadmin ] || mkdir -p {$dataPath}/fileadmin ; }");
         $this->assertCommandExecuted("{ [ -d {$dataPath}/uploads ] || mkdir -p {$dataPath}/uploads ; }");
+        $this->assertCommandExecuted("rm -rf '{$releasePath}/web'/fileadmin");
+        $this->assertCommandExecuted("rm -rf '{$releasePath}/web'/uploads");
         $this->assertCommandExecuted("ln -sf ../{$dataPath}/fileadmin '{$releasePath}/web'/fileadmin");
         $this->assertCommandExecuted("ln -sf ../{$dataPath}/uploads '{$releasePath}/web'/uploads");
     }
@@ -109,6 +115,8 @@ class SymlinkDataTaskTest extends BaseTaskTest
         $this->assertCommandExecuted("cd '{$releasePath}'");
         $this->assertCommandExecuted("{ [ -d {$dataPath}/fileadmin ] || mkdir -p {$dataPath}/fileadmin ; }");
         $this->assertCommandExecuted("{ [ -d {$dataPath}/uploads ] || mkdir -p {$dataPath}/uploads ; }");
+        $this->assertCommandExecuted("rm -rf '{$releasePath}/web'/fileadmin");
+        $this->assertCommandExecuted("rm -rf '{$releasePath}/web'/uploads");
         $this->assertCommandExecuted("ln -sf ../{$dataPath}/fileadmin '{$releasePath}/web'/fileadmin");
         $this->assertCommandExecuted("ln -sf ../{$dataPath}/uploads '{$releasePath}/web'/uploads");
         $this->assertCommandExecuted("{ [ -d '{$dataPath}/pictures' ] || mkdir -p '{$dataPath}/pictures' ; }");

--- a/src/Task/TYPO3/CMS/SymlinkDataTask.php
+++ b/src/Task/TYPO3/CMS/SymlinkDataTask.php
@@ -41,6 +41,8 @@ class SymlinkDataTask extends \TYPO3\Surf\Domain\Model\Task implements \TYPO3\Su
             'cd ' . escapeshellarg($targetReleasePath),
             "{ [ -d {$relativeDataPath}/fileadmin ] || mkdir -p {$relativeDataPath}/fileadmin ; }",
             "{ [ -d {$relativeDataPath}/uploads ] || mkdir -p {$relativeDataPath}/uploads ; }",
+            "rm -rf {$absoluteWebDirectory}/fileadmin",
+            "rm -rf {$absoluteWebDirectory}/uploads",
             "ln -sf {$relativeDataPathFromWeb}/fileadmin {$absoluteWebDirectory}/fileadmin",
             "ln -sf {$relativeDataPathFromWeb}/uploads {$absoluteWebDirectory}/uploads"
         );


### PR DESCRIPTION
\TYPO3\Surf\Task\TYPO3\CMS\SymlinkDataTask creates symlinks for the
“fileadmin” and “uploads” directories. These symlinks have to be created
in the web directory. Until now this will fail if a directory “fileadmin”
or a directory “uploads” already exist in the web directory when this
task is executed: the symlinks would then be created inside those two
directories.

Those two directories can get created during the
TYPO3\Surf\DefinedTask\Composer\LocalInstallTask when the project’s
root composer.json defines a script like this one to be run on “composer
install”:

@php vendor/bin/typo3cms install:fixfolderstructure

Such a script can be found in https://github.com/helhum/TYPO3-Distribution/blob/master/composer.json.

Therefore this commit makes sure that those directories are deleted if
they exist before the symlinks are created.

Note: TYPO3\Surf\DefinedTask\Composer\LocalInstallTask is defined in
\TYPO3\Surf\Application\BaseApplication::registerTasksForPackageMethod()