### PR TITLE
[FEATURE] make base directory for relative symlinks configurable

### DIFF
--- a/src/Task/Generic/CreateSymlinksTask.php
+++ b/src/Task/Generic/CreateSymlinksTask.php
@@ -41,8 +41,14 @@ class CreateSymlinksTask extends \TYPO3\Surf\Domain\Model\Task implements \TYPO3
             return;
         }
 
+        if (isset($options['genericSymlinksBaseDir']) && !empty($options['genericSymlinksBaseDir'])) {
+            $baseDirectory = $options['genericSymlinksBaseDir'];
+        } else {
+            $baseDirectory = $deployment->getApplicationReleasePath($application);
+        }
+
         $commands = array(
-            'cd ' . $deployment->getApplicationReleasePath($application)
+            'cd ' . $baseDirectory
         );
         foreach ($options['symlinks'] as $linkPath => $sourcePath) {
             $commands[] = 'ln -s ' . $sourcePath . ' ' . $linkPath;


### PR DESCRIPTION
The CreateGenericSymlinkTask creates relative symlinks by default in
application release path.

This commit adds the option "genericSymlinksBaseDir" to allow
a different base directory for relative symlinks.

Suggestions for better option naming  are welcome.