### PR TITLE
[FEATURE] make shared path configurable

### DIFF
--- a/Tests/Unit/Domain/Model/ApplicationTest.php
+++ b/Tests/Unit/Domain/Model/ApplicationTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace TYPO3\Surf\Tests\Unit\Domain\Model;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 project "TYPO3 Surf".                 *
+ *                                                                        *
+ *                                                                        */
+
+use TYPO3\Surf\Domain\Model\Application;
+
+/**
+ * Unit test for Application
+ */
+class ApplicationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * The directory for shared assets is by default 'shared'
+     *
+     * @test
+     * @return void
+     */
+    public function getSharedDirectoryReturnsDefaultIfNoOptionsGiven()
+    {
+        $application = new Application('TestApplication');
+        $this->assertEquals('shared', $application->getSharedDirectory());
+    }
+
+    /**
+     * If option 'sharedDirectory' is configured we expect this to be returned
+     * by getSharedDirectory
+     *
+     * @test
+     * @return void
+     */
+    public function getSharedDirectoryReturnsContentOfOptionIfConfigured()
+    {
+        $application = new Application('TestApplication');
+        $application->setOption('sharedDirectory', 'sharedAssets');
+        $this->assertEquals('sharedAssets', $application->getSharedDirectory());
+    }
+
+    /**
+     * Relative paths are not allowed as sharedDirectory
+     * we expect an exception on relative Paths
+     *
+     * @test
+     * @expectedException \TYPO3\Surf\Exception\InvalidConfigurationException
+     * @return void
+     */
+    public function getSharedDirectoryThrowsExceptionOnRelativePaths()
+    {
+        $application = new Application('TestApplication');
+        $application->setOption('sharedDirectory', '../sharedAssets');
+        $application->getSharedDirectory();
+    }
+}
+

--- a/src/Domain/Model/Application.php
+++ b/src/Domain/Model/Application.php
@@ -15,6 +15,13 @@ use TYPO3\Surf\Exception\InvalidConfigurationException;
 class Application
 {
     /**
+     * default directory name for shared directory
+     *
+     * @const
+     */
+    const DEFAULT_SHARED_DIR = 'shared';
+
+    /**
      * The name
      * @var string
      */
@@ -173,7 +180,33 @@ class Application
      */
     public function getSharedPath()
     {
-        return $this->getDeploymentPath() . '/shared';
+        return $this->getDeploymentPath() . '/' . $this->getSharedDirectory();
+    }
+
+    /**
+     * Returns the shared directory
+     *
+     * takes directory name from option "sharedDirectory"
+     * if option is not set or empty constant DEFAULT_SHARED_DIR "shared" is used
+     *
+     * @return string
+     * @throws InvalidConfigurationException
+     */
+    public function getSharedDirectory()
+    {
+        $result = self::DEFAULT_SHARED_DIR;
+        if ($this->hasOption('sharedDirectory') && !empty($this->getOption('sharedDirectory'))) {
+            $sharedPath = $this->getOption('sharedDirectory');
+            if (preg_match('/(^|\/)\.\.(\/|$)/', $sharedPath)) {
+                throw new InvalidConfigurationException(
+                    sprintf('Relative constructs as "../" are not allowed in option "sharedDirectory". Given option: "%s"',
+                        $sharedPath),
+                    1490107183141
+                );
+            }
+            $result = rtrim($sharedPath, '/');
+        }
+        return $result;
     }
 
     /**


### PR DESCRIPTION
The path for shared assests is unconfigurable fixed string in
application model. This change adds a new option "sharedDirectory"
which is used to get the shared path.
The related logic has been put in a separate getter "getSharedDirectory"