### PR TITLE
[FEATURE] Add stream_context option to WebOpcacheResetExecuteTask

### DIFF
--- a/src/Task/Php/WebOpcacheResetExecuteTask.php
+++ b/src/Task/Php/WebOpcacheResetExecuteTask.php
@@ -35,10 +35,15 @@ class WebOpcacheResetExecuteTask extends \TYPO3\Surf\Domain\Model\Task
             throw new \TYPO3\Surf\Exception\InvalidConfigurationException('No "scriptIdentifier" option provided for WebOpcacheResetExecuteTask, make sure to execute "TYPO3\\Surf\\Task\\Php\\WebOpcacheResetCreateScriptTask" before this task or pass one explicitly', 1421932610);
         }
 
+        $context = null;
+        if (isset($options['context']) && is_array($options['context'])) {
+            $context = stream_context_create($options['context']);
+        }
+
         $scriptIdentifier = $options['scriptIdentifier'];
         $scriptUrl = rtrim($options['baseUrl'], '/') . '/surf-opcache-reset-' . $scriptIdentifier . '.php';
 
-        $result = file_get_contents($scriptUrl);
+        $result = file_get_contents($scriptUrl, $context);
         if ($result !== 'success') {
             $deployment->getLogger()->warning('Executing PHP opcache reset script at "' . $scriptUrl . '" did not return expected result');
         }

--- a/src/Task/Php/WebOpcacheResetExecuteTask.php
+++ b/src/Task/Php/WebOpcacheResetExecuteTask.php
@@ -35,15 +35,15 @@ class WebOpcacheResetExecuteTask extends \TYPO3\Surf\Domain\Model\Task
             throw new \TYPO3\Surf\Exception\InvalidConfigurationException('No "scriptIdentifier" option provided for WebOpcacheResetExecuteTask, make sure to execute "TYPO3\\Surf\\Task\\Php\\WebOpcacheResetCreateScriptTask" before this task or pass one explicitly', 1421932610);
         }
 
-        $context = null;
-        if (isset($options['context']) && is_array($options['context'])) {
-            $context = stream_context_create($options['context']);
+        $streamContext = null;
+        if (isset($options['stream_context']) && is_array($options['stream_context'])) {
+            $streamContext = stream_context_create($options['stream_context']);
         }
 
         $scriptIdentifier = $options['scriptIdentifier'];
         $scriptUrl = rtrim($options['baseUrl'], '/') . '/surf-opcache-reset-' . $scriptIdentifier . '.php';
 
-        $result = file_get_contents($scriptUrl, $context);
+        $result = file_get_contents($scriptUrl, $streamContext);
         if ($result !== 'success') {
             $deployment->getLogger()->warning('Executing PHP opcache reset script at "' . $scriptUrl . '" did not return expected result');
         }


### PR DESCRIPTION
- This is useful for example to execute the task if we have to provide Basic Authentication