### PR TITLE
Disable public key authentication if password is provided

### DIFF
--- a/Tests/Unit/Task/TYPO3/Flow/CopyConfigurationTaskTest.php
+++ b/Tests/Unit/Task/TYPO3/Flow/CopyConfigurationTaskTest.php
@@ -93,6 +93,28 @@ class CopyConfigurationTaskTest extends BaseTaskTest
     /**
      * @test
      */
+    public function executeOnRemoteHostFindsConfigurationRecursivelyWithSSHPassword()
+    {
+        $deployBasePath = __DIR__ . '/Fixtures/DeploymentConfigurations';
+        $this->deployment->setDeploymentBasePath($deployBasePath);
+        $this->deployment->setName('test1');
+        $this->node->setHostname('remote');
+        $this->node->setOption('password', 'password1');
+
+        $this->task->execute($this->node, $this->application, $this->deployment, array());
+
+        $configPath = $this->deployment->getDeploymentConfigurationPath();
+        $releasesPath = $this->deployment->getApplicationReleasePath($this->application);
+
+        $this->assertCommandExecuted("ssh -o PubkeyAuthentication=no remote \"mkdir -p '{$releasesPath}/Configuration/'\"");
+        $this->assertCommandExecuted("scp -o PubkeyAuthentication=no '{$configPath}/Settings.yaml' remote:\"'{$releasesPath}/Configuration/'\"");
+        $this->assertCommandExecuted("ssh -o PubkeyAuthentication=no remote \"mkdir -p '{$releasesPath}/Configuration/Production/'\"");
+        $this->assertCommandExecuted("scp -o PubkeyAuthentication=no '{$configPath}/Production/Settings.yaml' remote:\"'{$releasesPath}/Configuration/Production/'\"");
+    }
+
+    /**
+     * @test
+     */
     public function executeOnRemoteHostCorrectlyAppliesSshOptions()
     {
         $deployBasePath = __DIR__ . '/Fixtures/DeploymentConfigurations';

--- a/Tests/Unit/Task/Transfer/RsyncTaskTest.php
+++ b/Tests/Unit/Task/Transfer/RsyncTaskTest.php
@@ -45,6 +45,22 @@ class RsyncTaskTest extends BaseTaskTest
     /**
      * @test
      */
+    public function executeWithUsernameAndPasswordAndDefaultOptionsCreatesDirectoryAndTransfersAndCopiesFiles()
+    {
+        $this->node->setOption('hostname', 'myserver.local');
+        $this->node->setOption('username', 'jdoe');
+        $this->node->setOption('password', 'jdoe');
+
+        $this->task->execute($this->node, $this->application, $this->deployment, array());
+
+        $this->assertCommandExecuted('mkdir -p /home/jdoe/app/cache/transfer');
+        $this->assertCommandExecuted('/rsync -q --compress --rsh="ssh -o PubkeyAuthentication=no"  --recursive --times --perms --links --delete --delete-excluded --exclude \'.git\' \'.*\/Data\/Surf\/TestDeployment\/TestApplication\/.\' \'jdoe@myserver.local:\/home\/jdoe\/app\/cache\/transfer\'/');
+        $this->assertCommandExecuted('/cp -RPp \/home\/jdoe\/app\/cache\/transfer\/. \/home\/jdoe\/app\/releases\/[0-9]+/');
+    }
+
+    /**
+     * @test
+     */
     public function executeWithPrivateKeyAddsFlagToSshCommand()
     {
         $this->node->setOption('hostname', 'myserver.local');

--- a/src/Task/Transfer/RsyncTask.php
+++ b/src/Task/Transfer/RsyncTask.php
@@ -41,10 +41,11 @@ class RsyncTask extends \TYPO3\Surf\Domain\Model\Task implements \TYPO3\Surf\Dom
 
         $username = $node->hasOption('username') ? $node->getOption('username') . '@' : '';
         $hostname = $node->getHostname();
+        $noPubkeyAuthentication = $node->hasOption('password') ? ' -o PubkeyAuthentication=no' : '';
         $port = $node->hasOption('port') ? ' -p ' . escapeshellarg($node->getOption('port')) : '';
         $key = $node->hasOption('privateKeyFile') ? ' -i ' . escapeshellarg($node->getOption('privateKeyFile')) : '';
         $quietFlag = (isset($options['verbose']) && $options['verbose']) ? '' : '-q';
-        $rshFlag = ($node->isLocalhost() ? '' : '--rsh="ssh' . $port . $key . '" ');
+        $rshFlag = ($node->isLocalhost() ? '' : '--rsh="ssh' . $noPubkeyAuthentication . $port . $key . '" ');
 
         $rsyncExcludes = isset($options['rsyncExcludes']) ? $options['rsyncExcludes'] : array('.git');
         $excludeFlags = $this->getExcludeFlags($rsyncExcludes);


### PR DESCRIPTION
Scenario: Public key authentication is set up, but we configured Surf to use a password instead. It makes sense in our environment, because Surf is run by Jenkins and some Jenkins stages should only be allowed to run if the server password is provided.

It is already done for remote SSH commands ([here](https://github.com/TYPO3/Surf/blob/51dd7ebd3c0ea5d2e6b74fb606e4ca3db3e909ff/src/Domain/Service/ShellCommandService.php#L131-L133)), but Rsync commands currently fail in this case, because public key authentication kicks in and succeeds before expect can enter the password.

```
send: spawn id exp6 not open     while executing "send -- "$password\r""     (file "[...]/PasswordSshLogin.expect" line 14)
```