### PR TITLE
Make $arguments flat nested array to be able to convert it to string

### DIFF
--- a/src/Task/Neos/Flow/SetFilePermissionsTask.php
+++ b/src/Task/Neos/Flow/SetFilePermissionsTask.php
@@ -48,7 +48,7 @@ class SetFilePermissionsTask extends Task implements ShellCommandServiceAwareInt
         ];
 
         $this->shell->executeOrSimulate($application->buildCommand($targetPath, 'core:setfilepermissions',
-            [$arguments]), $node, $deployment);
+            $arguments), $node, $deployment);
     }
 
     /**


### PR DESCRIPTION
Hey,

i had trouble running "SetFilePermissionsTask".

```
"PHP Warning:  escapeshellarg() expects parameter 1 to be string, array given"
```

Changing `[$arguments]` to `$arguments` fixed the issue