### PR TITLE
[TASK] Unify starting directory for generic CreateSymlinksTask

### DIFF
--- a/src/Task/Generic/CreateSymlinksTask.php
+++ b/src/Task/Generic/CreateSymlinksTask.php
@@ -41,8 +41,10 @@ class CreateSymlinksTask extends \TYPO3\Surf\Domain\Model\Task implements \TYPO3
             return;
         }
 
+        $baseDirectory = isset($options['baseDirectory']) ? $options['baseDirectory'] : $deployment->getApplicationReleasePath($application);
+
         $commands = array(
-            'cd ' . $deployment->getApplicationReleasePath($application)
+            'cd ' . $baseDirectory
         );
         foreach ($options['symlinks'] as $linkPath => $sourcePath) {
             $commands[] = 'ln -s ' . $sourcePath . ' ' . $linkPath;


### PR DESCRIPTION
The `\TYPO3\Surf\Task\Generic\CreateSymlinksTask` uses the application release path (https://github.com/TYPO3/Surf/blob/master/src/Task/Generic/CreateSymlinksTask.php#L45) as starting directory, while the `\TYPO3\Surf\Task\Generic\CreateDirectoriesTask` prefers the `baseDirectory` option.