### PR TITLE
[TASK] Add documentation boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 phpunit.xml
 vendor/
+/Documentation-GENERATED-temp

--- a/Documentation/Includes.txt
+++ b/Documentation/Includes.txt
@@ -1,0 +1,14 @@
+.. This is 'Includes.txt'. It is included at the very top of each and
+   every ReST source file in THIS documentation project (= manual).
+
+.. role:: aspect (emphasis)
+.. role:: html(code)
+.. role:: js(code)
+.. role:: php(code)
+.. role:: typoscript(code)
+
+.. role:: ts(typoscript)
+   :class: typoscript
+
+.. default-role:: code
+.. highlight:: php

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,0 +1,49 @@
+.. -*- coding: utf-8 -*- with BOM.
+.. include:: Includes.txt
+
+TYPO3 Surf |version| documentation
+==================================
+
+.. only:: html
+
+   :Classification:
+      deployment
+
+   :Version:
+      |release|
+
+   :Language:
+      en
+
+   :Keywords:
+      surf
+
+   :Copyright:
+      2018
+
+   :Author:
+      The contributors of the TYPO3 Surf project
+
+   :License:
+      The deployment package is licensed under GNU General Public License, version 3 or later
+      (http://www.gnu.org/licenses/gpl.html). Initial development was sponsored by
+      [networkteam - Flow Framework Agentur](https://networkteam.com/fokus/flow-framework.html).
+
+
+   :Rendered:
+      |today|
+
+   The content of this document is related to TYPO3,
+   a GNU/GPL CMS/Framework available from `www.typo3.org <http://www.typo3.org/>`_.
+
+
+   **Table of Contents**
+
+.. toctree::
+     :maxdepth: 2
+     :titlesonly:
+     :glob:
+
+     Quickstart/Index
+     Migration/Index
+

--- a/Documentation/Migration.md
+++ b/Documentation/Migration.md
@@ -1,6 +1,0 @@
-# Migration for deployment scripts when switching form 0.9.x to 2.0.0
-
-1. Move deployment scripts form `Build/Surf` to `~/.surf/deployments`
-1. Rename task or use migrate command to switch to new task names
-1. Set `transferMethod` and `packageMethod` options in your application, as the default changed from git to rsync 
-1. Change options for `CreateDirectoriesTask`: Now the specified directories are based on the application's release path not the general deployment path (which did not make much sense)

--- a/Documentation/Migration/Index.rst
+++ b/Documentation/Migration/Index.rst
@@ -1,0 +1,13 @@
+.. -*- coding: utf-8 -*- with BOM.
+.. include:: ../Includes.txt
+
+===================================================================
+Migration for deployment scripts when switching from 0.9.x to 2.0.0
+===================================================================
+
+1. Move deployment scripts form `Build/Surf` to `~/.surf/deployments`
+#. Rename task or use migrate command to switch to new task names
+#. Set `transferMethod` and `packageMethod` options in your application,
+   as the default changed from git to rsync
+#. Change options for `CreateDirectoriesTask`: Now the specified directories are based on the application's release
+   path not the general deployment path (which did not make much sense)

--- a/Documentation/Quickstart/Flow/Index.rst
+++ b/Documentation/Quickstart/Flow/Index.rst
@@ -1,0 +1,7 @@
+.. -*- coding: utf-8 -*- with BOM.
+.. include:: ../../Includes.txt
+
+=======================
+How to deploy Flow Apps
+=======================
+

--- a/Documentation/Quickstart/Index.rst
+++ b/Documentation/Quickstart/Index.rst
@@ -1,0 +1,15 @@
+.. -*- coding: utf-8 -*- with BOM.
+.. include:: ../Includes.txt
+
+============================================================
+How to quickly setup deployments for different kinds of apps
+============================================================
+
+.. toctree::
+   :maxdepth: 5
+   :titlesonly:
+
+   TYPO3/Index
+   Neos/Index
+   Flow/Index
+   Other/Index

--- a/Documentation/Quickstart/Neos/Index.rst
+++ b/Documentation/Quickstart/Neos/Index.rst
@@ -1,0 +1,7 @@
+.. -*- coding: utf-8 -*- with BOM.
+.. include:: ../../Includes.txt
+
+===========================
+How to deploy Neos websites
+===========================
+

--- a/Documentation/Quickstart/Other/Index.rst
+++ b/Documentation/Quickstart/Other/Index.rst
@@ -1,0 +1,7 @@
+.. -*- coding: utf-8 -*- with BOM.
+.. include:: ../../Includes.txt
+
+=====================================
+How to deploy other apps and websites
+=====================================
+

--- a/Documentation/Quickstart/TYPO3/Index.rst
+++ b/Documentation/Quickstart/TYPO3/Index.rst
@@ -1,0 +1,7 @@
+.. -*- coding: utf-8 -*- with BOM.
+.. include:: ../../Includes.txt
+
+============================
+How to deploy TYPO3 websites
+============================
+

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,0 +1,27 @@
+[general]
+
+project = Surf
+release = 2.0.0
+version = 2.0
+copyright = 2018
+
+[notify]
+
+about_new_build = no
+
+[html_theme_options]
+
+github_branch             = master
+github_repository         = TYPO3/Surf
+path_to_documentation_dir = Documentation
+
+project_home         = https://github.com/TYPO3/Surf
+project_issues       = https://github.com/TYPO3/Surf/issues
+project_repository   = https://github.com/TYPO3/Surf
+
+[intersphinx_mapping]
+
+t3tsref = http://docs.typo3.org/typo3cms/TyposcriptReference/
+t3editors = http://docs.typo3.org/typo3cms/EditorsTutorial/
+t3start = http://docs.typo3.org/typo3cms/GettingStartedTutorial/
+

--- a/Documentation/Settings.yml
+++ b/Documentation/Settings.yml
@@ -1,0 +1,26 @@
+---
+conf.py:
+  copyright: 2018
+  project: Surf
+  version: 2.0
+  release: 2.0.0
+  latex_documents:
+  - - Index
+  html_theme_options:
+    github_repository: TYPO3/Surf
+    github_branch: master
+  latex_elements:
+    papersize: a4paper
+    pointsize: 10pt
+    preamble: \usepackage{typo3}
+  intersphinx_mapping:
+    t3tsref:
+    - http://docs.typo3.org/typo3cms/TyposcriptReference/
+    - null
+    t3start:
+    - http://docs.typo3.org/typo3cms/GettingStartedTutorial/
+    - null
+    t3editors:
+    - http://docs.typo3.org/typo3cms/EditorsTutorial/
+    - null
+...

--- a/README.md
+++ b/README.md
@@ -333,6 +333,15 @@ process is simple:
 
 The generated `surf.phar` should work as expectd.
 
+## Contributing to the documentation
+
+You can simply edit or add a .rst file in the `Documentation` folder on Github and create a pull request.
+
+The online documentation will automatically update after changes to the master branch.
+To preview the documentation locally please follow this [guide](https://github.com/t3docs/docker-render-documentation).
+
+The documentation was set up according to the [TYPO3 documentation guide](https://docs.typo3.org/typo3cms/RenderTYPO3DocumentationGuide/Index.html).
+
 ## Copyright
 
 The deployment package is licensed under GNU General Public License, version 3 or later


### PR DESCRIPTION
This change add the necessary boilerplate
for the new documentation.
The setup will then be also compatible with
the TYPO3 documentation project.
See the updated readme for details.

Relates: #34