### PR TITLE
[TASK] Mark SourceforgeUploadTask as deprecated

### DIFF
--- a/src/ErrorMessageFactory.php
+++ b/src/ErrorMessageFactory.php
@@ -20,4 +20,12 @@ final class ErrorMessageFactory
         return 'The usage of coreapi is deprecated. Please use typo3_console instead. Integration in TYPO3 Surf will be removed in Version 3.0.0';
     }
 
+    /**
+     * @return string
+     */
+    public static function createDeprecationWarningForSourceforgeUploadTask()
+    {
+        return 'The usage of SourceforgeUploadTask is deprecated and will be removed in TYPO3 Surf Version 3.0.0';
+    }
+
 }

--- a/src/Task/SourceforgeUploadTask.php
+++ b/src/Task/SourceforgeUploadTask.php
@@ -11,6 +11,7 @@ namespace TYPO3\Surf\Task;
 use TYPO3\Surf\Domain\Model\Application;
 use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Node;
+use TYPO3\Surf\ErrorMessageFactory;
 use TYPO3\Surf\Exception\InvalidConfigurationException;
 
 /**
@@ -32,6 +33,7 @@ class SourceforgeUploadTask extends \TYPO3\Surf\Domain\Model\Task implements \TY
      */
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = array())
     {
+        $deployment->getLogger()->warning(ErrorMessageFactory::createDeprecationWarningForSourceforgeUploadTask());
         $this->checkOptionsForValidity($options);
         $projectName = $options['sourceforgeProjectName'];
 


### PR DESCRIPTION
The SourceforgeUploadTask is in my opinion very outdated these days. We should remove this task in Version 3.0.0. To do so we should mark this task as deprecated as early as possible.