### PR TITLE
[BUGFIX] Prevent cycle for task TYPO3\Surf\Task\Generic\CreateDirecto…

### DIFF
--- a/src/Application/BaseApplication.php
+++ b/src/Application/BaseApplication.php
@@ -14,7 +14,8 @@ use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Workflow;
 use TYPO3\Surf\Task\CleanupReleasesTask;
 use TYPO3\Surf\Task\Composer\InstallTask;
-use TYPO3\Surf\Task\Generic\CreateDirectoriesTask;
+use TYPO3\Surf\Task\CreateDirectoriesTask;
+use TYPO3\Surf\Task\Generic\CreateDirectoriesTask as GenericCreateDirectoriesTask;
 use TYPO3\Surf\Task\Generic\CreateSymlinksTask;
 use TYPO3\Surf\Task\GitCheckoutTask;
 use TYPO3\Surf\Task\Package\GitTask;
@@ -87,7 +88,7 @@ class BaseApplication extends Application
      */
     public function registerTasks(Workflow $workflow, Deployment $deployment)
     {
-        $this->setOption(CreateDirectoriesTask::class . '[directories]', $this->getDirectories());
+        $this->setOption(GenericCreateDirectoriesTask::class . '[directories]', $this->getDirectories());
         $this->setOption(CreateSymlinksTask::class . '[symlinks]', $this->getSymlinks());
 
         if ($this->hasOption('packageMethod')) {
@@ -108,7 +109,7 @@ class BaseApplication extends Application
 
         $workflow
             ->addTask(CreateDirectoriesTask::class, 'initialize', $this)
-            ->afterTask(CreateDirectoriesTask::class, CreateDirectoriesTask::class, $this)
+            ->afterTask(CreateDirectoriesTask::class, GenericCreateDirectoriesTask::class, $this)
             ->addTask(SymlinkReleaseTask::class, 'switch', $this)
             ->addTask(CleanupReleasesTask::class, 'cleanup', $this);
     }


### PR DESCRIPTION
…riesTask

Import TYPO3\Surf\Task\Generic\CreateDirectoriesTask as GenericCreateDirectoriesTask and TYPO3\Surf\Task\CreateDirectoriesTask
and add GenericCreateDirectoriesTask after CreateDirectoriesTask like before.

Resolves: #161

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
Not yet

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
#161


* **What is the new behavior (if this is a feature change)?**
Fixed #161


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**: