### PR TITLE
[TASK] Loosen constraint for Flow 4.x+ compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^5.6 || >=7.0 <7.3",
         "monolog/monolog": "^1.17",
-        "neos/utility-files": "^3.0",
+        "neos/utility-files": "^3.0 || ^4.0 || ^5.0",
         "padraic/phar-updater": "^1.0",
         "psr/log": "^1.0",
         "symfony/console": "^3.0 || ^4.0",


### PR DESCRIPTION
Loosens the constraint on `neos/utility-files` to allow installing with Flow 4.x, 5.x