### PR TITLE
[FEATURE] Add symfony OptionsResolver to configure options in tasks

### DIFF
--- a/Documentation/ApiReference/Domain/Model/Task.rst
+++ b/Documentation/ApiReference/Domain/Model/Task.rst
@@ -46,3 +46,14 @@ TYPO3\\Surf\\Domain\\Model\\Task
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/CleanupReleasesTask.rst
+++ b/Documentation/ApiReference/Task/CleanupReleasesTask.rst
@@ -67,3 +67,14 @@ TYPO3\\Surf\\Task\\CleanupReleasesTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Composer/AbstractComposerTask.rst
+++ b/Documentation/ApiReference/Task/Composer/AbstractComposerTask.rst
@@ -95,3 +95,14 @@ TYPO3\\Surf\\Task\\Composer\\AbstractComposerTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Composer/DownloadTask.rst
+++ b/Documentation/ApiReference/Task/Composer/DownloadTask.rst
@@ -66,3 +66,14 @@ TYPO3\\Surf\\Task\\Composer\\DownloadTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Composer/InstallTask.rst
+++ b/Documentation/ApiReference/Task/Composer/InstallTask.rst
@@ -110,3 +110,14 @@ TYPO3\\Surf\\Task\\Composer\\InstallTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/CreateArchiveTask.rst
+++ b/Documentation/ApiReference/Task/CreateArchiveTask.rst
@@ -84,3 +84,14 @@ TYPO3\\Surf\\Task\\CreateArchiveTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/CreateDirectoriesTask.rst
+++ b/Documentation/ApiReference/Task/CreateDirectoriesTask.rst
@@ -63,3 +63,14 @@ TYPO3\\Surf\\Task\\CreateDirectoriesTask
 
         :type $shellCommandService: ShellCommandService
         :param $shellCommandService:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/DumpDatabaseTask.rst
+++ b/Documentation/ApiReference/Task/DumpDatabaseTask.rst
@@ -89,3 +89,14 @@ TYPO3\\Surf\\Task\\DumpDatabaseTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Generic/CreateDirectoriesTask.rst
+++ b/Documentation/ApiReference/Task/Generic/CreateDirectoriesTask.rst
@@ -55,6 +55,11 @@ TYPO3\\Surf\\Task\\Generic\\CreateDirectoriesTask
         :type $options: array
         :param $options:
 
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:
+
     .. php:method:: setShellCommandService(ShellCommandService $shellCommandService)
 
         :type $shellCommandService: ShellCommandService
@@ -72,3 +77,9 @@ TYPO3\\Surf\\Task\\Generic\\CreateDirectoriesTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array

--- a/Documentation/ApiReference/Task/Generic/CreateSymlinksTask.rst
+++ b/Documentation/ApiReference/Task/Generic/CreateSymlinksTask.rst
@@ -65,3 +65,14 @@ TYPO3\\Surf\\Task\\Generic\\CreateSymlinksTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Generic/RollbackTask.rst
+++ b/Documentation/ApiReference/Task/Generic/RollbackTask.rst
@@ -49,3 +49,14 @@ TYPO3\\Surf\\Task\\Generic\\RollbackTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Git/AbstractCheckoutTask.rst
+++ b/Documentation/ApiReference/Task/Git/AbstractCheckoutTask.rst
@@ -88,3 +88,14 @@ TYPO3\\Surf\\Task\\Git\\AbstractCheckoutTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Git/PushTask.rst
+++ b/Documentation/ApiReference/Task/Git/PushTask.rst
@@ -70,3 +70,14 @@ TYPO3\\Surf\\Task\\Git\\PushTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Git/TagTask.rst
+++ b/Documentation/ApiReference/Task/Git/TagTask.rst
@@ -88,3 +88,14 @@ TYPO3\\Surf\\Task\\Git\\TagTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/GitCheckoutTask.rst
+++ b/Documentation/ApiReference/Task/GitCheckoutTask.rst
@@ -96,3 +96,14 @@ TYPO3\\Surf\\Task\\GitCheckoutTask
 
         :type $shellCommandService: ShellCommandService
         :param $shellCommandService:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/LocalShellTask.rst
+++ b/Documentation/ApiReference/Task/LocalShellTask.rst
@@ -70,3 +70,14 @@ TYPO3\\Surf\\Task\\LocalShellTask
 
         :type $shellCommandService: ShellCommandService
         :param $shellCommandService:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/LockDeploymentTask.rst
+++ b/Documentation/ApiReference/Task/LockDeploymentTask.rst
@@ -51,3 +51,14 @@ TYPO3\\Surf\\Task\\LockDeploymentTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Neos/Flow/CopyConfigurationTask.rst
+++ b/Documentation/ApiReference/Task/Neos/Flow/CopyConfigurationTask.rst
@@ -66,3 +66,14 @@ TYPO3\\Surf\\Task\\Neos\\Flow\\CopyConfigurationTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Neos/Flow/CreateDirectoriesTask.rst
+++ b/Documentation/ApiReference/Task/Neos/Flow/CreateDirectoriesTask.rst
@@ -40,6 +40,11 @@ TYPO3\\Surf\\Task\\Neos\\Flow\\CreateDirectoriesTask
         :type $options: array
         :param $options:
 
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:
+
     .. php:method:: setShellCommandService(ShellCommandService $shellCommandService)
 
         :type $shellCommandService: ShellCommandService
@@ -57,3 +62,9 @@ TYPO3\\Surf\\Task\\Neos\\Flow\\CreateDirectoriesTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array

--- a/Documentation/ApiReference/Task/Neos/Flow/FlushCacheListTask.rst
+++ b/Documentation/ApiReference/Task/Neos/Flow/FlushCacheListTask.rst
@@ -70,3 +70,14 @@ TYPO3\\Surf\\Task\\Neos\\Flow\\FlushCacheListTask
 
         :type $shellCommandService: ShellCommandService
         :param $shellCommandService:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Neos/Flow/FunctionalTestTask.rst
+++ b/Documentation/ApiReference/Task/Neos/Flow/FunctionalTestTask.rst
@@ -57,3 +57,14 @@ TYPO3\\Surf\\Task\\Neos\\Flow\\FunctionalTestTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Neos/Flow/MigrateTask.rst
+++ b/Documentation/ApiReference/Task/Neos/Flow/MigrateTask.rst
@@ -57,3 +57,14 @@ TYPO3\\Surf\\Task\\Neos\\Flow\\MigrateTask
 
         :type $shellCommandService: ShellCommandService
         :param $shellCommandService:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Neos/Flow/PublishResourcesTask.rst
+++ b/Documentation/ApiReference/Task/Neos/Flow/PublishResourcesTask.rst
@@ -57,3 +57,14 @@ TYPO3\\Surf\\Task\\Neos\\Flow\\PublishResourcesTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Neos/Flow/RunCommandTask.rst
+++ b/Documentation/ApiReference/Task/Neos/Flow/RunCommandTask.rst
@@ -78,3 +78,14 @@ TYPO3\\Surf\\Task\\Neos\\Flow\\RunCommandTask
 
         :type $shellCommandService: ShellCommandService
         :param $shellCommandService:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Neos/Flow/SetFilePermissionsTask.rst
+++ b/Documentation/ApiReference/Task/Neos/Flow/SetFilePermissionsTask.rst
@@ -70,3 +70,14 @@ TYPO3\\Surf\\Task\\Neos\\Flow\\SetFilePermissionsTask
 
         :type $shellCommandService: ShellCommandService
         :param $shellCommandService:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Neos/Flow/SymlinkConfigurationTask.rst
+++ b/Documentation/ApiReference/Task/Neos/Flow/SymlinkConfigurationTask.rst
@@ -59,3 +59,14 @@ TYPO3\\Surf\\Task\\Neos\\Flow\\SymlinkConfigurationTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Neos/Flow/SymlinkDataTask.rst
+++ b/Documentation/ApiReference/Task/Neos/Flow/SymlinkDataTask.rst
@@ -57,3 +57,14 @@ TYPO3\\Surf\\Task\\Neos\\Flow\\SymlinkDataTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Neos/Flow/UnitTestTask.rst
+++ b/Documentation/ApiReference/Task/Neos/Flow/UnitTestTask.rst
@@ -57,3 +57,14 @@ TYPO3\\Surf\\Task\\Neos\\Flow\\UnitTestTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Neos/Neos/ImportSiteTask.rst
+++ b/Documentation/ApiReference/Task/Neos/Neos/ImportSiteTask.rst
@@ -69,3 +69,14 @@ TYPO3\\Surf\\Task\\Neos\\Neos\\ImportSiteTask
 
         :type $shellCommandService: ShellCommandService
         :param $shellCommandService:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Package/GitTask.rst
+++ b/Documentation/ApiReference/Task/Package/GitTask.rst
@@ -114,3 +114,14 @@ TYPO3\\Surf\\Task\\Package\\GitTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Php/WebOpcacheResetCreateScriptTask.rst
+++ b/Documentation/ApiReference/Task/Php/WebOpcacheResetCreateScriptTask.rst
@@ -81,3 +81,14 @@ TYPO3\\Surf\\Task\\Php\\WebOpcacheResetCreateScriptTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Php/WebOpcacheResetExecuteTask.rst
+++ b/Documentation/ApiReference/Task/Php/WebOpcacheResetExecuteTask.rst
@@ -65,3 +65,14 @@ TYPO3\\Surf\\Task\\Php\\WebOpcacheResetExecuteTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Release/AddDownloadTask.rst
+++ b/Documentation/ApiReference/Task/Release/AddDownloadTask.rst
@@ -62,3 +62,14 @@ TYPO3\\Surf\\Task\\Release\\AddDownloadTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Release/PrepareReleaseTask.rst
+++ b/Documentation/ApiReference/Task/Release/PrepareReleaseTask.rst
@@ -38,12 +38,10 @@ TYPO3\\Surf\\Task\\Release\\PrepareReleaseTask
         :type $options: array
         :param $options:
 
-    .. php:method:: checkOptionsForValidity($options)
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
 
-        Check if all required options are given
-
-        :type $options: array
-        :param $options:
+        :type $resolver: OptionsResolver
+        :param $resolver:
 
     .. php:method:: setShellCommandService(ShellCommandService $shellCommandService)
 
@@ -62,3 +60,9 @@ TYPO3\\Surf\\Task\\Release\\PrepareReleaseTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array

--- a/Documentation/ApiReference/Task/Release/ReleaseTask.rst
+++ b/Documentation/ApiReference/Task/Release/ReleaseTask.rst
@@ -38,12 +38,10 @@ TYPO3\\Surf\\Task\\Release\\ReleaseTask
         :type $options: array
         :param $options:
 
-    .. php:method:: checkOptionsForValidity($options)
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
 
-        Check if all required options are given
-
-        :type $options: array
-        :param $options:
+        :type $resolver: OptionsResolver
+        :param $resolver:
 
     .. php:method:: setShellCommandService(ShellCommandService $shellCommandService)
 
@@ -62,3 +60,9 @@ TYPO3\\Surf\\Task\\Release\\ReleaseTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array

--- a/Documentation/ApiReference/Task/RsyncFoldersTask.rst
+++ b/Documentation/ApiReference/Task/RsyncFoldersTask.rst
@@ -74,3 +74,14 @@ TYPO3\\Surf\\Task\\RsyncFoldersTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/ShellTask.rst
+++ b/Documentation/ApiReference/Task/ShellTask.rst
@@ -70,3 +70,14 @@ TYPO3\\Surf\\Task\\ShellTask
 
         :type $shellCommandService: ShellCommandService
         :param $shellCommandService:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/SourceforgeUploadTask.rst
+++ b/Documentation/ApiReference/Task/SourceforgeUploadTask.rst
@@ -85,3 +85,14 @@ TYPO3\\Surf\\Task\\SourceforgeUploadTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/StopTask.rst
+++ b/Documentation/ApiReference/Task/StopTask.rst
@@ -50,3 +50,14 @@ TYPO3\\Surf\\Task\\StopTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/SymlinkReleaseTask.rst
+++ b/Documentation/ApiReference/Task/SymlinkReleaseTask.rst
@@ -57,3 +57,14 @@ TYPO3\\Surf\\Task\\SymlinkReleaseTask
 
         :type $shellCommandService: ShellCommandService
         :param $shellCommandService:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/TYPO3/CMS/AbstractCliTask.rst
+++ b/Documentation/ApiReference/Task/TYPO3/CMS/AbstractCliTask.rst
@@ -181,3 +181,14 @@ TYPO3\\Surf\\Task\\TYPO3\\CMS\\AbstractCliTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/TYPO3/CMS/ActivatePackagesTask.rst
+++ b/Documentation/ApiReference/Task/TYPO3/CMS/ActivatePackagesTask.rst
@@ -195,3 +195,14 @@ TYPO3\\Surf\\Task\\TYPO3\\CMS\\ActivatePackagesTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/TYPO3/CMS/CompareDatabaseTask.rst
+++ b/Documentation/ApiReference/Task/TYPO3/CMS/CompareDatabaseTask.rst
@@ -204,3 +204,14 @@ TYPO3\\Surf\\Task\\TYPO3\\CMS\\CompareDatabaseTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/TYPO3/CMS/CopyConfigurationTask.rst
+++ b/Documentation/ApiReference/Task/TYPO3/CMS/CopyConfigurationTask.rst
@@ -66,3 +66,14 @@ TYPO3\\Surf\\Task\\TYPO3\\CMS\\CopyConfigurationTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/TYPO3/CMS/CreatePackageStatesTask.rst
+++ b/Documentation/ApiReference/Task/TYPO3/CMS/CreatePackageStatesTask.rst
@@ -195,3 +195,14 @@ TYPO3\\Surf\\Task\\TYPO3\\CMS\\CreatePackageStatesTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/TYPO3/CMS/FlushCachesTask.rst
+++ b/Documentation/ApiReference/Task/TYPO3/CMS/FlushCachesTask.rst
@@ -194,3 +194,14 @@ TYPO3\\Surf\\Task\\TYPO3\\CMS\\FlushCachesTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/TYPO3/CMS/RunCommandTask.rst
+++ b/Documentation/ApiReference/Task/TYPO3/CMS/RunCommandTask.rst
@@ -193,3 +193,14 @@ TYPO3\\Surf\\Task\\TYPO3\\CMS\\RunCommandTask
 
         :type $shellCommandService: ShellCommandService
         :param $shellCommandService:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/TYPO3/CMS/SetUpExtensionsTask.rst
+++ b/Documentation/ApiReference/Task/TYPO3/CMS/SetUpExtensionsTask.rst
@@ -182,3 +182,14 @@ TYPO3\\Surf\\Task\\TYPO3\\CMS\\SetUpExtensionsTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/TYPO3/CMS/SymlinkDataTask.rst
+++ b/Documentation/ApiReference/Task/TYPO3/CMS/SymlinkDataTask.rst
@@ -56,3 +56,14 @@ TYPO3\\Surf\\Task\\TYPO3\\CMS\\SymlinkDataTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Test/HttpTestTask.rst
+++ b/Documentation/ApiReference/Task/Test/HttpTestTask.rst
@@ -130,3 +130,14 @@ TYPO3\\Surf\\Task\\Test\\HttpTestTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/Transfer/RsyncTask.rst
+++ b/Documentation/ApiReference/Task/Transfer/RsyncTask.rst
@@ -67,3 +67,14 @@ TYPO3\\Surf\\Task\\Transfer\\RsyncTask
 
         :type $shellCommandService: ShellCommandService
         :param $shellCommandService:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/UnlockDeploymentTask.rst
+++ b/Documentation/ApiReference/Task/UnlockDeploymentTask.rst
@@ -49,3 +49,14 @@ TYPO3\\Surf\\Task\\UnlockDeploymentTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Documentation/ApiReference/Task/VarnishBanTask.rst
+++ b/Documentation/ApiReference/Task/VarnishBanTask.rst
@@ -53,6 +53,11 @@ TYPO3\\Surf\\Task\\VarnishBanTask
         :type $options: array
         :param $options:
 
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:
+
     .. php:method:: setShellCommandService(ShellCommandService $shellCommandService)
 
         :type $shellCommandService: ShellCommandService
@@ -70,3 +75,9 @@ TYPO3\\Surf\\Task\\VarnishBanTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array

--- a/Documentation/ApiReference/Task/VarnishPurgeTask.rst
+++ b/Documentation/ApiReference/Task/VarnishPurgeTask.rst
@@ -70,3 +70,14 @@ TYPO3\\Surf\\Task\\VarnishPurgeTask
         :param $deployment:
         :type $options: array
         :param $options:
+
+    .. php:method:: configureOptions($options = [])
+
+        :type $options: array
+        :param $options:
+        :returns: array
+
+    .. php:method:: resolveOptions(OptionsResolver $resolver)
+
+        :type $resolver: OptionsResolver
+        :param $resolver:

--- a/Tests/Unit/Task/Release/PrepareReleaseTaskTest.php
+++ b/Tests/Unit/Task/Release/PrepareReleaseTaskTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace TYPO3\Surf\Tests\Unit\Task\Release;
+
+/*
+ * This file is part of TYPO3 Surf.
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use TYPO3\Surf\Task\Release\ReleaseTask;
+use TYPO3\Surf\Tests\Unit\Task\BaseTaskTest;
+
+class PrepareReleaseTaskTest extends BaseTaskTest
+{
+
+    /**
+     * @test
+     */
+    public function requiredReleaseHostOptionIsMissing()
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->task->execute($this->node, $this->application, $this->deployment);
+    }
+
+    /**
+     * @test
+     */
+    public function requiredOptionsAreDefinedTaskSuccessfullyExecuted()
+    {
+        $options = [
+            'releaseHost' => 'releaseHost',
+            'releaseHostLogin' => 'releaseHostLogin',
+            'changeLogUri' => 'changeLogUri',
+            'releaseHostSitePath' => 'releaseHostSitePath',
+            'version' => 'version',
+            'productName' => 'productName',
+        ];
+
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted('ssh releaseHostLogin@releaseHost "cd \"releaseHostSitePath\" ; ./flow release:release --product-name \"productName\" --version \"version\" --change-log-uri \"changeLogUri\""');
+    }
+
+    /**
+     * @return ReleaseTask
+     */
+    protected function createTask()
+    {
+        return new ReleaseTask();
+    }
+}

--- a/Tests/Unit/Task/VarnishBanTaskTest.php
+++ b/Tests/Unit/Task/VarnishBanTaskTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace TYPO3\Surf\Tests\Unit\Task;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\Surf\Task\VarnishBanTask;
+
+class VarnishBanTaskTest extends BaseTaskTest
+{
+
+    /**
+     * @var VarnishBanTask
+     */
+    protected $task;
+
+    /**
+     * @test
+     */
+    public function executeWithDefaultOptions()
+    {
+        $this->task->execute($this->node, $this->application, $this->deployment, []);
+        $this->assertCommandExecuted("/\/usr\/bin\/varnishadm -S \/etc\/varnish\/secret -T 127.0.0.1:6082 ban.url '.*'/");
+    }
+
+    /**
+     * @test
+     */
+    public function executeOverridingDefaultOptions()
+    {
+        $options = [
+            'varnishadm' => 'varnishadm',
+            'secretFile' => 'secretFile',
+            'banUrl' => 'banUrl',
+        ];
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted("/varnishadm -S secretFile -T 127.0.0.1:6082 ban.url 'banUrl'/");
+    }
+
+    /**
+     * @test
+     */
+    public function simulateWithDefaultOptions()
+    {
+        $this->task->simulate($this->node, $this->application, $this->deployment, []);
+        $this->assertCommandExecuted("/\/usr\/bin\/varnishadm -S \/etc\/varnish\/secret -T 127.0.0.1:6082 status/");
+    }
+
+    /**
+     * @test
+     */
+    public function simulateOverridingDefaultOptions()
+    {
+        $options = [
+            'varnishadm' => 'varnishadm',
+            'secretFile' => 'secretFile',
+            'banUrl' => 'banUrl',
+        ];
+        $this->task->simulate($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted('/varnishadm -S secretFile -T 127.0.0.1:6082 status/');
+    }
+
+    /**
+     * @return VarnishBanTask
+     */
+    protected function createTask()
+    {
+        return new VarnishBanTask();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "psr/log": "^1.0",
         "symfony/console": "^3.0 || ^4.0",
         "symfony/process": "^3.0 || ^4.0",
-        "paragonie/random_compat": "^2.0"
+        "paragonie/random_compat": "^2.0",
+        "symfony/options-resolver": "^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07e831e210cf166c1a576ecf0fbf3270",
+    "content-hash": "b183466fa7ff191fbde84c0f68c16ece",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -443,6 +443,60 @@
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
             "time": "2018-04-30T16:53:52+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "8e68c053a39e26559357cc742f01a7182ce40785"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/8e68c053a39e26559357cc742f01a7182ce40785",
+                "reference": "8e68c053a39e26559357cc742f01a7182ce40785",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "time": "2015-11-18T13:48:51+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2556,60 +2610,6 @@
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
             "time": "2018-04-04T05:07:11+00:00"
-        },
-        {
-            "name": "symfony/options-resolver",
-            "version": "v3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "8e68c053a39e26559357cc742f01a7182ce40785"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/8e68c053a39e26559357cc742f01a7182ce40785",
-                "reference": "8e68c053a39e26559357cc742f01a7182ce40785",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\OptionsResolver\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony OptionsResolver Component",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "config",
-                "configuration",
-                "options"
-            ],
-            "time": "2015-11-18T13:48:51+00:00"
         },
         {
             "name": "symfony/polyfill-php70",

--- a/src/Domain/Model/Task.php
+++ b/src/Domain/Model/Task.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace TYPO3\Surf\Domain\Model;
 
 /*
@@ -8,11 +9,22 @@ namespace TYPO3\Surf\Domain\Model;
  * file that was distributed with this source code.
  */
 
+use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\OptionsResolver\Exception\NoConfigurationException;
+use Symfony\Component\OptionsResolver\Exception\NoSuchOptionException;
+use Symfony\Component\OptionsResolver\Exception\OptionDefinitionException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use TYPO3\Surf\Exception\InvalidConfigurationException;
+
 /**
  * A task
  */
 abstract class Task
 {
+
     /**
      * Executes this action
      *
@@ -33,6 +45,7 @@ abstract class Task
      */
     public function rollback(Node $node, Application $application, Deployment $deployment, array $options = [])
     {
+        $this->configureOptions($options);
     }
 
     /**
@@ -45,5 +58,47 @@ abstract class Task
      */
     public function simulate(Node $node, Application $application, Deployment $deployment, array $options = [])
     {
+        $this->configureOptions($options);
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array
+     * @throws \Exception
+     */
+    protected function configureOptions(array $options = [])
+    {
+        try {
+            $resolver = new OptionsResolver();
+            // We set all global options as defined options, otherwise we would get a lot of exceptions
+            $resolver->setDefined(array_keys($options));
+            $this->resolveOptions($resolver);
+            return $resolver->resolve($options);
+        } catch (MissingOptionsException $e) {
+            throw new InvalidOptionsException($e->getMessage(), $e->getCode());
+        } catch (InvalidOptionsException $e) {
+            throw new InvalidConfigurationException($e->getMessage(), $e->getCode());
+        } catch (NoConfigurationException $e) {
+            throw new InvalidConfigurationException($e->getMessage(), $e->getCode());
+        } catch (NoSuchOptionException $e) {
+            throw new InvalidConfigurationException($e->getMessage(), $e->getCode());
+        } catch (OptionDefinitionException $e) {
+            throw new InvalidConfigurationException($e->getMessage(), $e->getCode());
+        } catch (UndefinedOptionsException $e) {
+            throw new InvalidConfigurationException($e->getMessage(), $e->getCode());
+        } catch (ExceptionInterface $e) {
+            throw new InvalidConfigurationException($e->getMessage(), $e->getCode());
+        }
+    }
+
+    /**
+     * @param OptionsResolver $resolver
+     *
+     * @throws \Exception
+     */
+    protected function resolveOptions(OptionsResolver $resolver)
+    {
+        // Configure your options here, required, normalization etc.
     }
 }

--- a/src/Task/Release/PrepareReleaseTask.php
+++ b/src/Task/Release/PrepareReleaseTask.php
@@ -8,13 +8,13 @@ namespace TYPO3\Surf\Task\Release;
  * file that was distributed with this source code.
  */
 
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use TYPO3\Surf\Domain\Model\Application;
 use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Node;
 use TYPO3\Surf\Domain\Model\Task;
 use TYPO3\Surf\Domain\Service\ShellCommandServiceAwareInterface;
 use TYPO3\Surf\Domain\Service\ShellCommandServiceAwareTrait;
-use TYPO3\Surf\Exception\InvalidConfigurationException;
 
 /**
  * Task for preparing a "TYPO3.Release" release
@@ -33,7 +33,8 @@ class PrepareReleaseTask extends Task implements ShellCommandServiceAwareInterfa
      */
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = [])
     {
-        $this->checkOptionsForValidity($options);
+        $options = $this->configureOptions($options);
+
         $host = $options['releaseHost'];
         $login = $options['releaseHostLogin'];
         $sitePath =  $options['releaseHostSitePath'];
@@ -57,17 +58,10 @@ class PrepareReleaseTask extends Task implements ShellCommandServiceAwareInterfa
     }
 
     /**
-     * Check if all required options are given
-     *
-     * @param array $options
-     * @throws \TYPO3\Surf\Exception\InvalidConfigurationException
+     * @param OptionsResolver $resolver
      */
-    protected function checkOptionsForValidity(array $options)
+    protected function resolveOptions(OptionsResolver $resolver)
     {
-        foreach (['releaseHost', 'releaseHostSitePath', 'version', 'productName'] as $optionName) {
-            if (!isset($options[$optionName])) {
-                throw new InvalidConfigurationException('"' . $optionName . '" option not set', 1321549659);
-            }
-        }
+        $resolver->setRequired(['releaseHost', 'releaseHostSitePath', 'version', 'productName']);
     }
 }

--- a/src/Task/Release/ReleaseTask.php
+++ b/src/Task/Release/ReleaseTask.php
@@ -28,7 +28,8 @@ class ReleaseTask extends PrepareReleaseTask
      */
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = [])
     {
-        $this->checkOptionsForValidity($options);
+        $options = $this->configureOptions($options);
+
         $host = $options['releaseHost'];
         $login = $options['releaseHostLogin'];
         $changeLogUri = $options['changeLogUri'];


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x ] Tests for the changes have been added


* **What kind of change does this PR introduce?** 
This introduces the OptionsResolver component from Symfony to configure the options in every task.


* **What is the current behavior?** 
At the moment the configuration of options in the tasks includes a lot of boilerplate code.
Makes it sometimes really hard to read and to understand.


* **What is the new behavior?**
You can now override the method resolveOptions of the abstract Task class to configure your options (required, default values) for your custom task.


* **Does this PR introduce a breaking change?** 
In the future this could maybe lead to a breaking change, because we now have some other exception messages and exception codes. But this is not very likely that someone is relying on the exception message or code.