### PR TITLE
[CLEANUP] Remove dependency psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "monolog/monolog": "^1.17",
         "neos/utility-files": "^3.0",
         "padraic/phar-updater": "^1.0",
-        "psr/log": "^1.0",
         "symfony/console": "^3.0 || ^4.0",
         "symfony/process": "^3.0 || ^4.0",
         "paragonie/random_compat": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11ad816af4668f9eba04712578ef29af",
+    "content-hash": "7d0670e0e6658345c77124b82a3a0c03",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",


### PR DESCRIPTION
On the hand we are requiring monolog as a concrete implementation of the PSR-3 standard, but on the other hand we requiring the common interface for logging libraries psr/log itself. 
This gives the wrong impression that you could choose one of the existing concrete implementations of the PSR-3 standard. 