### PR TITLE
[TASK] Allow paragonie/random_compat v9.99

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "padraic/phar-updater": "^1.0",
         "symfony/console": "^3.0 || ^4.0",
         "symfony/process": "^3.0 || ^4.0",
-        "paragonie/random_compat": "^2.0",
+        "paragonie/random_compat": "^2.0 || ^9.99",
         "symfony/options-resolver": "^3.0 || ^4.0",
         "guzzlehttp/guzzle": "^6.0"
     },


### PR DESCRIPTION
This patch allows the actual version of paragonie/random_compat.