### PR TITLE
[TASK] Change documentation navigation structure to simplify reading

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -44,8 +44,8 @@ TYPO3 Surf |version| documentation
      :titlesonly:
      :glob:
 
-     GettingStarted/Index
      Installation/Index
+     Usage/Index
      Architecture/Index
      DeploymentFlow/Index
      Applications/Index

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -1,11 +1,9 @@
 .. -*- coding: utf-8 -*- with BOM.
 .. include:: ../Includes.txt
 
-===============
-Getting Started
-===============
-
-First of all you have to :doc:`install Surf <../Installation/Index>`.
+=====
+Usage
+=====
 
 After installing Surf you have to create one or more deployment configuration files for your project.
 The deployment configuration files are at the moment just plain php files.


### PR DESCRIPTION
- Renamed "Getting Started" to "Usage"
- Move "Installation" up in the menu
- Removed link to "Getting Started" (now "Usage") from "Installation" page