### PR TITLE
[!!!][BUGFIX] Don't run composer install on remote by default for Flo…

### DIFF
--- a/Tests/Unit/Command/DescribeCommandTest.php
+++ b/Tests/Unit/Command/DescribeCommandTest.php
@@ -270,7 +270,7 @@ Applications:
     Options: 
       packageMethod => <success>git</success>
       transferMethod => <success>rsync</success>
-      updateMethod => <success>composer</success>
+      updateMethod => <success>NULL</success>
       lockDeployment => <success>1</success>
       TYPO3\Surf\Task\Generic\CreateDirectoriesTask[directories] =>
       TYPO3\Surf\Task\Generic\CreateSymlinksTask[symlinks] =>
@@ -297,8 +297,6 @@ Applications:
         after:
           <success>TYPO3\Surf\Task\Generic\CreateSymlinksTask</success> (for application Neos)
       update:
-        tasks:
-          <success>TYPO3\Surf\Task\Composer\InstallTask</success> (for application Neos)
         after:
           <success>TYPO3\Surf\Task\Neos\Flow\SymlinkDataTask</success> (for application Neos)
           <success>TYPO3\Surf\Task\Neos\Flow\SymlinkConfigurationTask</success> (for application Neos)

--- a/src/Application/Neos/Flow.php
+++ b/src/Application/Neos/Flow.php
@@ -43,9 +43,6 @@ class Flow extends BaseApplication
     public function __construct($name = 'Neos Flow')
     {
         parent::__construct($name);
-        $this->options = array_merge($this->options, [
-            'updateMethod' => 'composer'
-        ]);
     }
 
     /**


### PR DESCRIPTION
…w Apps

As the new default is to composer install on the deploying host and rsync the files to the remote node,
it's not necessary to run composer install a 2nd time on the remote.

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
Install composer packages local and remote


* **What is the new behavior (if this is a feature change)?**
Install composer packages local 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
In cases, were the `transferMethod` is git and `updateMethod` is not explicit set to composer.


* **Other information**: