### PR TITLE
[TASK] Add .ddev to default rsync excludes of TYPO3

### DIFF
--- a/Tests/Unit/Command/DescribeCommandTest.php
+++ b/Tests/Unit/Command/DescribeCommandTest.php
@@ -201,6 +201,7 @@ Applications:
         <success>fileadmin</success>
         <success>uploads</success>
       rsyncExcludes =>
+        <success>.ddev</success>
         <success>.git</success>
         <success>web/fileadmin</success>
         <success>web/uploads</success>

--- a/src/Application/TYPO3/CMS.php
+++ b/src/Application/TYPO3/CMS.php
@@ -61,6 +61,7 @@ class CMS extends BaseApplication
                 'fileadmin', 'uploads'
             ],
             'rsyncExcludes' => [
+                '.ddev',
                 '.git',
                 'web/fileadmin',
                 'web/uploads'


### PR DESCRIPTION
Resolves: #257

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add `.ddev` to default rsyncExcludes of TYPO3


* **What is the current behavior?** (You can also link to an open issue here)
`.ddev` get synced if it's not excluded


* **What is the new behavior (if this is a feature change)?**
`.ddev` is excluded by default for TYPO3


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Just if someone ships data from that folder. Very unlikely.


* **Other information**: