### PR TITLE
[TASK] Respect webDirectory when creating the file opcode cache reset…

### DIFF
--- a/Tests/Unit/Task/Php/WebOpcacheResetCreateScriptTaskTest.php
+++ b/Tests/Unit/Task/Php/WebOpcacheResetCreateScriptTaskTest.php
@@ -49,6 +49,23 @@ class WebOpcacheResetCreateScriptTaskTest extends BaseTaskTest
     /**
      * @test
      */
+    public function createScriptInWebDirectory()
+    {
+        $this->application->setOption('webDirectory', 'public');
+        $randomBytes = random_bytes(32);
+        $expectedScriptIdentifier = bin2hex($randomBytes);
+
+        $expectedScriptIdentifierPath = sprintf('%s/surf-opcache-reset-%s.php', Files::concatenatePaths([$this->deployment->getWorkspacePath($this->application), 'public']), $expectedScriptIdentifier);
+        $this->filesystem->expects($this->once())->method('put')->with($expectedScriptIdentifierPath)->willReturn(true);
+        $this->randomBytesGenerator->expects($this->once())->method('generate')->willReturn($randomBytes);
+        $this->task->execute($this->node, $this->application, $this->deployment);
+
+        $this->assertSame($expectedScriptIdentifier, $this->application->getOption(WebOpcacheResetExecuteTask::class . '[scriptIdentifier]'));
+    }
+
+    /**
+     * @test
+     */
     public function createScriptByDefinedIdentifier()
     {
         $scriptIdentifier = '123456';

--- a/src/Task/Php/WebOpcacheResetCreateScriptTask.php
+++ b/src/Task/Php/WebOpcacheResetCreateScriptTask.php
@@ -89,7 +89,8 @@ class WebOpcacheResetCreateScriptTask extends Task implements ShellCommandServic
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = [])
     {
         $workspacePath = $deployment->getWorkspacePath($application);
-        $scriptBasePath = isset($options['scriptBasePath']) ? $options['scriptBasePath'] : Files::concatenatePaths([$workspacePath, 'Web']);
+        $webDirectory = $application->hasOption('webDirectory') ? $application->getOption('webDirectory') : 'Web';
+        $scriptBasePath = isset($options['scriptBasePath']) ? $options['scriptBasePath'] : Files::concatenatePaths([$workspacePath, $webDirectory]);
 
         if (! isset($options['scriptIdentifier'])) {
             // Store the script identifier as an application option


### PR DESCRIPTION
… script

Resolves: #177

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Simplification


* **What is the current behavior?** (You can also link to an open issue here)
The webDirectory is not respected

* **What is the new behavior (if this is a feature change)?**
The webDirectory will be respected when the reset script is created 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**: