### PR TITLE
[TASK] Remove unnecessary scriptBasePath option

### DIFF
--- a/Documentation/Examples/TYPO3/Index.rst
+++ b/Documentation/Examples/TYPO3/Index.rst
@@ -31,7 +31,6 @@ If you would like to deploy a TYPO3 Website a good starting point is to use TYPO
            $application->getOption('webDirectory') . '/fileadmin',
            'packages/**.sass'
        ])
-       ->setOption('scriptBasePath', \TYPO3\Flow\Utility\Files::concatenatePaths([$deployment->getWorkspacePath($application), $application->getOption('webDirectory')]))
        ->addSymlink($application->getOption('webDirectory') . '/typo3conf/LocalConfiguration.php', '../../../../shared/Configuration/LocalConfiguration.php')
        ->addNode($node);
 


### PR DESCRIPTION
Since #177 is closed, scriptBasePath is not necessary anymore for TYPO3 CMS

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs