### PR TITLE
[TASK] Ignore platform requirements for LocalInstallTask

### DIFF
--- a/src/Application/BaseApplication.php
+++ b/src/Application/BaseApplication.php
@@ -251,14 +251,15 @@ class BaseApplication extends Application
             case 'git':
                 $workflow->addTask(GitTask::class, 'package', $this);
                 $workflow->defineTask(
-                    'TYPO3\\Surf\\DefinedTask\\Composer\\LocalInstallTask',
+                    $localInstallTask = 'TYPO3\\Surf\\DefinedTask\\Composer\\LocalInstallTask',
                     InstallTask::class,
                     [
                         'nodeName' => 'localhost',
                         'useApplicationWorkspace' => true,
+                        'additionalArguments' => ['--ignore-platform-reqs'],
                     ]
                 );
-                $workflow->afterTask(GitTask::class, 'TYPO3\\Surf\\DefinedTask\\Composer\\LocalInstallTask', $this);
+                $workflow->afterTask(GitTask::class, $localInstallTask, $this);
                 break;
         }
     }


### PR DESCRIPTION
As localhost that installs the application is not the same system that runs the application, it is useless to check the platform requirements.