### PR TITLE
Add "start" label on start page

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,6 +1,8 @@
 .. -*- coding: utf-8 -*- with BOM.
 .. include:: Includes.txt
 
+.. _start:
+
 TYPO3 Surf |version| documentation
 ==================================
 


### PR DESCRIPTION
As is customary for official TYPO3 documentation. This way, it is possible to link to the start page by using interphinx linking, such as:

:ref:`t3surf:start`

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**: