### PR TITLE
[BUGFIX] Use 'public' as webDirectory

### DIFF
--- a/src/Application/BaseApplication.php
+++ b/src/Application/BaseApplication.php
@@ -70,6 +70,7 @@ class BaseApplication extends Application
         'transferMethod' => 'rsync',
         'updateMethod' => null,
         'lockDeployment' => true,
+        'webDirectory' => self::DEFAULT_WEB_DIRECTORY,
     ];
 
     /**

--- a/src/Application/Neos/Flow.php
+++ b/src/Application/Neos/Flow.php
@@ -36,6 +36,8 @@ class Flow extends BaseApplication
      */
     protected $version = '4.0';
 
+    public const DEFAULT_WEB_DIRECTORY = 'Web';
+
     /**
      * Constructor
      * @param string $name
@@ -43,6 +45,10 @@ class Flow extends BaseApplication
     public function __construct($name = 'Neos Flow')
     {
         parent::__construct($name);
+
+        $this->options = array_merge($this->options, [
+            'webDirectory' => self::DEFAULT_WEB_DIRECTORY,
+        ]);
     }
 
     public function registerTasks(Workflow $workflow, Deployment $deployment)

--- a/src/Application/Neos/Neos.php
+++ b/src/Application/Neos/Neos.php
@@ -49,20 +49,24 @@ class Neos extends Flow
     ];
 
     /**
+     * @param string $name
+     */
+    public function __construct($name = 'Neos')
+    {
+        parent::__construct($name);
+
+        $this->options = array_merge($this->options, [
+            'webDirectory' => self::DEFAULT_WEB_DIRECTORY,
+        ]);
+    }
+
+    /**
      * @param string $command
      * @return bool
      */
     protected function isNeosCommand($command)
     {
         return in_array($command, $this->neosCommands);
-    }
-
-    /**
-     * @param string $name
-     */
-    public function __construct($name = 'Neos')
-    {
-        parent::__construct($name);
     }
 
     /**

--- a/src/Application/TYPO3/CMS.php
+++ b/src/Application/TYPO3/CMS.php
@@ -24,6 +24,30 @@ use TYPO3\Surf\Task\TYPO3\CMS\SymlinkDataTask;
 class CMS extends BaseApplication
 {
     /**
+     * Constructor
+     * @param string $name
+     */
+    public function __construct($name = 'TYPO3 CMS')
+    {
+        parent::__construct($name);
+
+        $this->options = array_merge($this->options, [
+            'context' => 'Production',
+            'scriptFileName' => 'vendor/bin/typo3cms',
+            'symlinkDataFolders' => [
+                'fileadmin',
+                'uploads'
+            ],
+            'rsyncExcludes' => [
+                '.ddev',
+                '.git',
+                '{webDirectory}/fileadmin',
+                '{webDirectory}/uploads'
+            ]
+        ]);
+    }
+
+    /**
      * Set the application production context
      *
      * @param string $context
@@ -43,29 +67,6 @@ class CMS extends BaseApplication
     public function getContext()
     {
         return $this->options['context'];
-    }
-
-    /**
-     * Constructor
-     * @param string $name
-     */
-    public function __construct($name = 'TYPO3 CMS')
-    {
-        parent::__construct($name);
-        $this->options = array_merge($this->options, [
-            'context' => 'Production',
-            'scriptFileName' => 'vendor/bin/typo3cms',
-            'webDirectory' => 'web',
-            'symlinkDataFolders' => [
-                'fileadmin', 'uploads'
-            ],
-            'rsyncExcludes' => [
-                '.ddev',
-                '.git',
-                '{webDirectory}/fileadmin',
-                '{webDirectory}/uploads'
-            ]
-        ]);
     }
 
     /**

--- a/src/Domain/Model/Application.php
+++ b/src/Domain/Model/Application.php
@@ -22,6 +22,8 @@ class Application
      */
     public const DEFAULT_SHARED_DIR = 'shared';
 
+    public const DEFAULT_WEB_DIRECTORY = 'public';
+
     /**
      * The name
      * @var string

--- a/src/Task/Php/WebOpcacheResetCreateScriptTask.php
+++ b/src/Task/Php/WebOpcacheResetCreateScriptTask.php
@@ -76,7 +76,7 @@ class WebOpcacheResetCreateScriptTask extends Task implements ShellCommandServic
         $options = $this->configureOptions($options);
 
         $workspacePath = $deployment->getWorkspacePath($application);
-        $webDirectory = $application->hasOption('webDirectory') ? $application->getOption('webDirectory') : 'Web';
+        $webDirectory = $application->hasOption('webDirectory') ? $application->getOption('webDirectory') : $application::DEFAULT_WEB_DIRECTORY;
         $scriptBasePath = $options['scriptBasePath'] ?: Files::concatenatePaths([$workspacePath, $webDirectory]);
 
         if ($options['scriptIdentifier'] === null) {

--- a/tests/Unit/Command/DescribeCommandTest.php
+++ b/tests/Unit/Command/DescribeCommandTest.php
@@ -220,9 +220,9 @@ Applications:
       transferMethod => <success>rsync</success>
       updateMethod => <success>NULL</success>
       lockDeployment => <success>1</success>
+      webDirectory => <success>public</success>
       context => <success>Production</success>
       scriptFileName => <success>vendor/bin/typo3cms</success>
-      webDirectory => <success>web</success>
       symlinkDataFolders =>
         <success>fileadmin</success>
         <success>uploads</success>
@@ -301,6 +301,7 @@ Applications:
       transferMethod => <success>rsync</success>
       updateMethod => <success>NULL</success>
       lockDeployment => <success>1</success>
+      webDirectory => <success>Web</success>
       TYPO3\Surf\Task\Generic\CreateDirectoriesTask[directories] =>
       TYPO3\Surf\Task\Generic\CreateSymlinksTask[symlinks] =>
       deploymentPath => <success>NULL</success>
@@ -372,6 +373,7 @@ Applications:
       transferMethod => <success>rsync</success>
       updateMethod => <success>NULL</success>
       lockDeployment => <success>1</success>
+      webDirectory => <success>public</success>
       TYPO3\Surf\Task\Generic\CreateDirectoriesTask[directories] =>
       TYPO3\Surf\Task\Generic\CreateSymlinksTask[symlinks] =>
       deploymentPath => <success>NULL</success>
@@ -434,6 +436,7 @@ Applications:
       transferMethod => <success>rsync</success>
       updateMethod => <success>NULL</success>
       lockDeployment => <success></success>
+      webDirectory => <success>public</success>
       TYPO3\Surf\Task\Generic\CreateDirectoriesTask[directories] =>
       TYPO3\Surf\Task\Generic\CreateSymlinksTask[symlinks] =>
       deploymentPath => <success>NULL</success>
@@ -494,6 +497,7 @@ Applications:
       transferMethod => <success>rsync</success>
       updateMethod => <success>NULL</success>
       lockDeployment => <success>1</success>
+      webDirectory => <success>public</success>
       TYPO3\Surf\Task\Generic\CreateDirectoriesTask[directories] =>
       TYPO3\Surf\Task\Generic\CreateSymlinksTask[symlinks] =>
       deploymentPath => <success>NULL</success>

--- a/tests/Unit/Task/Php/WebOpcacheResetCreateScriptTaskTest.php
+++ b/tests/Unit/Task/Php/WebOpcacheResetCreateScriptTaskTest.php
@@ -39,7 +39,7 @@ class WebOpcacheResetCreateScriptTaskTest extends BaseTaskTest
         $randomBytes = random_bytes(32);
         $expectedScriptIdentifier = bin2hex($randomBytes);
 
-        $expectedScriptIdentifierPath = sprintf('%s/surf-opcache-reset-%s.php', Files::concatenatePaths([$this->deployment->getWorkspacePath($this->application), 'Web']), $expectedScriptIdentifier);
+        $expectedScriptIdentifierPath = sprintf('%s/surf-opcache-reset-%s.php', Files::concatenatePaths([$this->deployment->getWorkspacePath($this->application), 'public']), $expectedScriptIdentifier);
         $this->filesystem->expects($this->once())->method('put')->with($expectedScriptIdentifierPath)->willReturn(true);
         $this->randomBytesGenerator->expects($this->once())->method('generate')->willReturn($randomBytes);
         $this->task->execute($this->node, $this->application, $this->deployment);
@@ -70,7 +70,7 @@ class WebOpcacheResetCreateScriptTaskTest extends BaseTaskTest
     public function createScriptByDefinedIdentifier()
     {
         $scriptIdentifier = '123456';
-        $expectedScriptIdentifierPath = sprintf('%s/surf-opcache-reset-%s.php', Files::concatenatePaths([$this->deployment->getWorkspacePath($this->application), 'Web']), $scriptIdentifier);
+        $expectedScriptIdentifierPath = sprintf('%s/surf-opcache-reset-%s.php', Files::concatenatePaths([$this->deployment->getWorkspacePath($this->application), 'public']), $scriptIdentifier);
         $this->filesystem->expects($this->once())->method('put')->with($expectedScriptIdentifierPath)->willReturn(true);
         $this->randomBytesGenerator->expects($this->never())->method('generate');
         $this->task->execute($this->node, $this->application, $this->deployment, ['scriptIdentifier' => $scriptIdentifier]);

--- a/tests/Unit/Task/Transfer/RsyncTaskTest.php
+++ b/tests/Unit/Task/Transfer/RsyncTaskTest.php
@@ -184,7 +184,7 @@ class RsyncTaskTest extends BaseTaskTest
 
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $this->assertCommandExecuted('/--recursive --times --perms --links --delete --delete-excluded --exclude \'.ddev\' --exclude \'.git\' --exclude \'web\/fileadmin\' --exclude \'web\/uploads\'/');
+        $this->assertCommandExecuted('/--recursive --times --perms --links --delete --delete-excluded --exclude \'.ddev\' --exclude \'.git\' --exclude \'public\/fileadmin\' --exclude \'public\/uploads\'/');
     }
 
     /**
@@ -193,13 +193,13 @@ class RsyncTaskTest extends BaseTaskTest
     public function executeWithTypo3CmsAndCustomWebDirectory()
     {
         $this->application = new CMS();
-        $this->application->setOption('webDirectory', 'public');
+        $this->application->setOption('webDirectory', 'web');
         $this->node->setOption('hostname', 'myserver.local');
         $options = $this->application->getOptions();
 
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $this->assertCommandExecuted('/--recursive --times --perms --links --delete --delete-excluded --exclude \'.ddev\' --exclude \'.git\' --exclude \'public\/fileadmin\' --exclude \'public\/uploads\'/');
+        $this->assertCommandExecuted('/--recursive --times --perms --links --delete --delete-excluded --exclude \'.ddev\' --exclude \'.git\' --exclude \'web\/fileadmin\' --exclude \'web\/uploads\'/');
     }
 
     /**


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
Bugfix

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Since TYPO3 9 the "official" web directory is 'public'. This is also default in many other frameworks like Laravel or Symfony.


* **What is the current behavior?** (You can also link to an open issue here)
web root directory is 'web'


* **What is the new behavior (if this is a feature change)?**
web root directory is 'public'


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Users who rely on surf defaults must change the option "webDirectory" to 'web'
