### PR TITLE
[BUGFIX] Don't force caches to be flushed

### DIFF
--- a/src/Task/TYPO3/CMS/FlushCachesTask.php
+++ b/src/Task/TYPO3/CMS/FlushCachesTask.php
@@ -56,7 +56,7 @@ class FlushCachesTask extends AbstractCliTask
     {
         switch ($this->getAvailableCliPackage($node, $application, $deployment, $options)) {
             case 'typo3_console':
-                return [$this->getConsoleScriptFileName($node, $application, $deployment, $options), 'cache:flush', '--force'];
+                return [$this->getConsoleScriptFileName($node, $application, $deployment, $options), 'cache:flush'];
             case 'coreapi':
                 $deployment->getLogger()->warning(DeprecationMessageFactory::createDeprecationWarningForCoreApiUsage());
                 return [$this->getCliDispatchScriptFileName($options), 'extbase', 'cacheapi:clearallcaches'];


### PR DESCRIPTION
With helhum/typo3-console v6.2.0 the `--force` argument creates an RuntimeException

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix the deprecation existing since 4 Jan 2019 (see https://github.com/TYPO3-Console/TYPO3-Console/commit/01bedaa7e0ff97d1d73187570d4686f7ddadfd78)

* **What is the current behavior?** (You can also link to an open issue here)

helhum/typo3-console v6.2.0:
```
cd ' TYPO3_CONTEXT='Production/Staging' /usr/local/php/bin/php 'vendor/bin/typo3cms' 'cache:flush' '--force'"
     > 
     > [ Symfony\Component\Console\Exception\RuntimeException ]     The "--force" option does not exist.
cache:flush [--files-only]
```
helhum/typo3-console v5.6.0-v6.1.0
```
TYPO3_CONTEXT='Production/Staging' /usr/local/php/bin/php 'vendor/bin/typo3cms' 'cache:flush' '--force'"
     > Using "--force" is deprecated and has no effect any more.
     > Flushed all caches.
```
* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Maybe breaking on older typo3-console versions

* **Other information**: