### PR TITLE
[TASK] Adds configurable opt. projectRootPath setting for Composer

### DIFF
--- a/src/Task/Composer/AbstractComposerTask.php
+++ b/src/Task/Composer/AbstractComposerTask.php
@@ -58,6 +58,10 @@ abstract class AbstractComposerTask extends Task implements ShellCommandServiceA
             $composerRootPath = $deployment->getApplicationReleasePath($application);
         }
 
+        if (isset($options['projectRootPath']) && $options['projectRootPath'] !== null) {
+            $composerRootPath = Files::concatenatePaths([$composerRootPath, $options['projectRootPath']]);
+        }
+
         if ($options['nodeName'] !== null) {
             $node = $deployment->getNode($options['nodeName']);
             if ($node === null) {
@@ -130,6 +134,7 @@ abstract class AbstractComposerTask extends Task implements ShellCommandServiceA
 
         $resolver->setDefault('useApplicationWorkspace', false);
         $resolver->setDefault('nodeName', null);
+        $resolver->setDefault('projectRootPath', null);
         $resolver->setAllowedTypes('additionalArguments', ['array', 'string']);
     }
 }

--- a/src/Task/Composer/AbstractComposerTask.php
+++ b/src/Task/Composer/AbstractComposerTask.php
@@ -58,7 +58,7 @@ abstract class AbstractComposerTask extends Task implements ShellCommandServiceA
             $composerRootPath = $deployment->getApplicationReleasePath($application);
         }
 
-        if (isset($options['projectRootPath']) && $options['projectRootPath'] !== null) {
+        if ($options['projectRootPath'] !== null) {
             $composerRootPath = Files::concatenatePaths([$composerRootPath, $options['projectRootPath']]);
         }
 

--- a/src/Task/Composer/CommandTask.php
+++ b/src/Task/Composer/CommandTask.php
@@ -26,6 +26,7 @@ use TYPO3\Surf\Domain\Model\Node;
  * * additionalArguments (optional) - Array of additional arguments to pass to composer and keep default arguments
  * * suffix (optional) - Array, string or null with the suffix command, either `['2>&1']`, `[]`, `'2>&1'`, `''` or `null`
  * * useApplicationWorkspace (optional) - If true Surf uses the workspace path, else it uses the release path of the application.
+ * * projectRootPath (optional) - The path, relative to the composerRootPath (derived from workspacePath or ApplicationReleasePath), if composer.json is not stored in the projects root folder
  *
  * Example:
  *  $workflow->defineTask('My\\Distribution\\DefinedTask\\RunBuildScript', \TYPO3\Surf\Task\Composer\CommandTask::class, [

--- a/src/Task/Composer/InstallTask.php
+++ b/src/Task/Composer/InstallTask.php
@@ -16,6 +16,7 @@ namespace TYPO3\Surf\Task\Composer;
  * * composerCommandPath - The path where composer is located.
  * * nodeName - The name of the node where composer should install the packages.
  * * useApplicationWorkspace (optional) - If true Surf uses the workspace path, else it uses the release path of the application.
+ * * projectRootPath (optional) - The path, relative to the composerRootPath (derived from workspacePath or ApplicationReleasePath), if composer.json is not stored in the projects root folder
  *
  * Example:
  *  $workflow

--- a/tests/Unit/Task/Composer/InstallTaskTest.php
+++ b/tests/Unit/Task/Composer/InstallTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace TYPO3\Surf\Tests\Unit\Task\Composer;
 
 /*
@@ -8,6 +9,7 @@ namespace TYPO3\Surf\Tests\Unit\Task\Composer;
  * file that was distributed with this source code.
  */
 
+use TYPO3\Flow\Utility\Files;
 use TYPO3\Surf\Domain\Model\Task;
 use TYPO3\Surf\Exception\InvalidConfigurationException;
 use TYPO3\Surf\Task\Composer\InstallTask;
@@ -76,6 +78,23 @@ class InstallTaskTest extends BaseTaskTest
 
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
         $this->assertCommandExecuted('/^composer install --no-ansi --no-interaction --no-dev --no-progress --classmap-authoritative \'--ignore-platform-reqs\' 2>&1$/');
+    }
+
+
+    /**
+     * @test
+     */
+    public function executeWithConfiguredComposerProjectRootPath()
+    {
+        $options = [
+            'composerCommandPath' => 'composer',
+            'projectRootPath' => '/var/www/projectRootPath',
+            'useApplicationWorkspace' => false,
+        ];
+
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+        $expectedCommand = escapeshellarg(sprintf('%s/composer.json', Files::concatenatePaths([$this->deployment->getApplicationReleasePath($this->application), $options['projectRootPath']])));
+        $this->assertCommandExecuted('/^test -f '.preg_quote($expectedCommand, '/').'$/');
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/TYPO3/Surf/issues/398

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
(I'm sorry, but not sure how to add a test for this feature)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature: A project's root path can be configured, so that the composer.json can be stored outside of the root (i.e. in a /server1, /server2 or /htdocs subdirectory where the rest of the distinct projects live).


* **What is the current behavior?** (You can also link to an open issue here)
Currently, composer.json is only looked for inside the project root


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**: