### PR TITLE
Make it possible to change the parameter of FlushCachesTask

### DIFF
--- a/Tests/Unit/Task/TYPO3/CMS/FlushCachesTaskTest.php
+++ b/Tests/Unit/Task/TYPO3/CMS/FlushCachesTaskTest.php
@@ -1,0 +1,51 @@
+<?php
+namespace TYPO3\Surf\Tests\Unit\Task\TYPO3\CMS;
+
+/*
+ * This file is part of TYPO3 Surf.
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+use TYPO3\Surf\Application\TYPO3\CMS;
+use TYPO3\Surf\Task\TYPO3\CMS\FlushCachesTask;
+use TYPO3\Surf\Tests\Unit\Task\BaseTaskTest;
+
+/**
+ * Class SetUpExtensionsTaskTest
+ */
+class FlushCachesTaskTest extends BaseTaskTest
+{
+    /**
+     * @var FlushCachesTask
+     */
+    protected $task;
+
+    /**
+     * @return FlushCachesTask
+     */
+    protected function createTask()
+    {
+        return new FlushCachesTask();
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->application = new CMS('TestApplication');
+        $this->application->setDeploymentPath('/home/jdoe/app');
+    }
+
+    /**
+     * @test
+     */
+    public function executeWithoutOptionExecutesCacheFlushWithForceParameter()
+    {
+        $options = [
+            'scriptFileName' => 'vendor/bin/typo3cms'
+        ];
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted("/php 'vendor\/bin\/typo3cms' 'cache:flush' '--force'$/");
+    }
+}

--- a/Tests/Unit/Task/TYPO3/CMS/FlushCachesTaskTest.php
+++ b/Tests/Unit/Task/TYPO3/CMS/FlushCachesTaskTest.php
@@ -48,4 +48,30 @@ class FlushCachesTaskTest extends BaseTaskTest
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
         $this->assertCommandExecuted("/php 'vendor\/bin\/typo3cms' 'cache:flush' '--force'$/");
     }
+
+    /**
+     * @test
+     */
+    public function executeWithEmptyArgumentsExecutesCacheFlushWithoutArguments()
+    {
+        $options = [
+            'scriptFileName' => 'vendor/bin/typo3cms',
+            'arguments' => []
+        ];
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted("/php 'vendor\/bin\/typo3cms' 'cache:flush'$/");
+    }
+
+    /**
+     * @test
+     */
+    public function executeWithFilesOnlyArgumentExecutesCacheFlushWithFilesOnlyArgument()
+    {
+        $options = [
+            'scriptFileName' => 'vendor/bin/typo3cms',
+            'arguments' => ['--files-only']
+        ];
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted("/php 'vendor\/bin\/typo3cms' 'cache:flush' '--files-only'$/");
+    }
 }

--- a/src/Task/TYPO3/CMS/FlushCachesTask.php
+++ b/src/Task/TYPO3/CMS/FlushCachesTask.php
@@ -8,6 +8,8 @@ namespace TYPO3\Surf\Task\TYPO3\CMS;
  * file that was distributed with this source code.
  */
 
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use TYPO3\Surf\Application\TYPO3\CMS;
 use TYPO3\Surf\DeprecationMessageFactory;
 use TYPO3\Surf\Domain\Model\Application;
@@ -31,6 +33,9 @@ class FlushCachesTask extends AbstractCliTask
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = [])
     {
         $this->ensureApplicationIsTypo3Cms($application);
+
+        $options = $this->configureOptions($options);
+
         $cliArguments = $this->getSuitableCliArguments($node, $application, $deployment, $options);
         if (empty($cliArguments)) {
             $deployment->getLogger()->warning('Neither Extension "typo3_console" nor "coreapi" was found! Make sure one is available in your project, or remove this task (' . __CLASS__ . ') in your deployment configuration!');
@@ -56,12 +61,24 @@ class FlushCachesTask extends AbstractCliTask
     {
         switch ($this->getAvailableCliPackage($node, $application, $deployment, $options)) {
             case 'typo3_console':
-                return [$this->getConsoleScriptFileName($node, $application, $deployment, $options), 'cache:flush', '--force'];
+                return array_merge([$this->getConsoleScriptFileName($node, $application, $deployment, $options), 'cache:flush'], $options['arguments']);
             case 'coreapi':
                 $deployment->getLogger()->warning(DeprecationMessageFactory::createDeprecationWarningForCoreApiUsage());
                 return [$this->getCliDispatchScriptFileName($options), 'extbase', 'cacheapi:clearallcaches'];
             default:
                 return [];
         }
+    }
+
+    /**
+     * @param OptionsResolver $resolver
+     */
+    protected function resolveOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefault('arguments', ['--force'])
+            ->setAllowedTypes('arguments', ['array', 'string'])
+            ->setNormalizer('arguments', function (Options $options, $value) {
+                return (array)$value;
+            });
     }
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Small feature change the default `--force` parameter of the FlushCachesTask


* **What is the current behavior?** (You can also link to an open issue here)
`--force` can't changed or left out and was removed with typo3-console 6.2
#396 


* **What is the new behavior (if this is a feature change)?**
The default `--force`  can be changed to `--files-only` or just an empty array

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**: