### PR TITLE
[BUGFIX] Prevent PHP warning by checking the type

### DIFF
--- a/Tests/Unit/Task/Neos/Flow/FlushCacheListTaskTest.php
+++ b/Tests/Unit/Task/Neos/Flow/FlushCacheListTaskTest.php
@@ -30,11 +30,21 @@ class FlushCacheListTaskTest extends BaseTaskTest
     /**
      * @test
      */
-    public function requiredOptionFlushCacheListNotGivenThrowsException()
+    public function requiredOptionFlushCacheListWithEmptyStringThrowsException()
     {
         $this->expectException(InvalidConfigurationException::class);
         $this->application = new Flow();
         $this->task->execute($this->node, $this->application, $this->deployment, ['flushCacheList' => '']);
+    }
+
+    /**
+     * @test
+     */
+    public function requiredOptionFlushCacheListWithEmptyArrayThrowsException()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->application = new Flow();
+        $this->task->execute($this->node, $this->application, $this->deployment, ['flushCacheList' => []]);
     }
 
     /**
@@ -51,10 +61,20 @@ class FlushCacheListTaskTest extends BaseTaskTest
     /**
      * @test
      */
-    public function executeSuccessfully()
+    public function executeSuccessfullyWithString()
     {
         $this->application = new Flow();
         $this->task->execute($this->node, $this->application, $this->deployment, ['flushCacheList' => 'list']);
+        $this->assertCommandExecuted(sprintf('cd /releases/%s && FLOW_CONTEXT=Production php ./flow neos.flow:cache:flushone \'--identifier\' \'list\'', $this->deployment->getReleaseIdentifier()));
+    }
+
+    /**
+     * @test
+     */
+    public function executeSuccessfullyWithArray()
+    {
+        $this->application = new Flow();
+        $this->task->execute($this->node, $this->application, $this->deployment, ['flushCacheList' => ['list']]);
         $this->assertCommandExecuted(sprintf('cd /releases/%s && FLOW_CONTEXT=Production php ./flow neos.flow:cache:flushone \'--identifier\' \'list\'', $this->deployment->getReleaseIdentifier()));
     }
 

--- a/src/Task/Neos/Flow/FlushCacheListTask.php
+++ b/src/Task/Neos/Flow/FlushCacheListTask.php
@@ -91,14 +91,20 @@ class FlushCacheListTask extends Task implements ShellCommandServiceAwareInterfa
      */
     protected function resolveOptions(OptionsResolver $resolver)
     {
-        $resolver->setRequired('flushCacheList');
-        $resolver->setAllowedValues('flushCacheList', static function ($value) {
-            return trim($value) !== '';
-        });
-
-        $resolver->setNormalizer('flushCacheList', static function (Options $options, $value) {
-            return is_array($value) ? $value : explode(',', $value);
-        });
+        $resolver->setRequired('flushCacheList')
+            ->setAllowedTypes('flushCacheList', ['array', 'string'])
+            ->setNormalizer('flushCacheList', static function (Options $options, $value) {
+                return is_array($value) ? $value : explode(',', $value);
+            })
+            ->setAllowedValues('flushCacheList', static function ($value) {
+                if (is_array($value)) {
+                    return !empty($value);
+                }
+                if (is_string($value)) {
+                    return trim($value) !== '';
+                }
+                return false;
+            });
 
         $resolver->setDefault('phpBinaryPathAndFilename', 'php')
             ->setAllowedTypes('phpBinaryPathAndFilename', 'string');


### PR DESCRIPTION
Resolves: #412
Releases: 2.1

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
PHP warning if an array is given as option because trim exprect a string.


* **What is the new behavior (if this is a feature change)?**
Check the type and handle the array.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**: