### PR TITLE
[BUGFIX] Use available cache and log directory

### DIFF
--- a/src/Cli/Symfony/ConsoleKernel.php
+++ b/src/Cli/Symfony/ConsoleKernel.php
@@ -58,4 +58,16 @@ final class ConsoleKernel extends Kernel
             [new Reference(ShellCommandService::class)]
         );
     }
+
+    public function getCacheDir(): string
+    {
+        // manually configured, so it can be replaced in phar
+        return sys_get_temp_dir() . '/_surf';
+    }
+
+    public function getLogDir(): string
+    {
+        // manually configured, so it can be replaced in phar
+        return sys_get_temp_dir() . '/_surf_log';
+    }
 }

--- a/src/Integration/Factory.php
+++ b/src/Integration/Factory.php
@@ -163,6 +163,8 @@ class Factory implements FactoryInterface, ContainerAwareInterface
         $this->ensureDirectoryExists($tempPath);
         $deployment->setTemporaryPath($tempPath);
 
+        $container = $this->container;
+
         require($deploymentPathAndFilename);
 
         return $deployment;


### PR DESCRIPTION
- For the phar context we need a cache and log directory for the DI-Container outside of the phar file