### PR TITLE
[TASK] Move deployment path from application to node

### DIFF
--- a/Documentation/Examples/Neos/Index.rst
+++ b/Documentation/Examples/Neos/Index.rst
@@ -14,6 +14,7 @@ If you would like to deploy a Neos website a good starting point is to use the N
    $node = new \TYPO3\Surf\Domain\Model\Node('production');
    $node
       ->setHostname('my.node.com')
+      ->setDeploymentPath('/var/www/html/my.node.com')
       ->setOption('username', 'myuser');
 
    $application = new \TYPO3\Surf\Application\Neos\Neos('My Node');
@@ -28,7 +29,6 @@ If you would like to deploy a Neos website a good starting point is to use the N
           'Neos_Fusion_Content',
           'Neos_Neos_Fusion'
       ])
-      ->setDeploymentPath('/var/www/html/my.node.com')
       ->addNode($node);
 
    $deployment

--- a/Documentation/Examples/TYPO3/Index.rst
+++ b/Documentation/Examples/TYPO3/Index.rst
@@ -14,12 +14,12 @@ If you would like to deploy a TYPO3 website a good starting point is to use TYPO
    $node = new \TYPO3\Surf\Domain\Model\Node('my.node.com');
    $node
        ->setHostname($node->getName())
+       ->setDeploymentPath('/httpdocs')
        ->setOption('username', 'myuser')
        ->setOption('phpBinaryPathAndFilename', '/usr/local/bin/php_cli');
 
    $application = new \TYPO3\Surf\Application\TYPO3\CMS();
    $application
-       ->setDeploymentPath('/httpdocs')
        ->setOption('baseUrl', 'https://my.node.com/')
        ->setOption('webDirectory', 'public')
        ->setOption('symlinkDataFolders', ['fileadmin'])

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -22,11 +22,11 @@ with name **MyDeployment**::
    <?php
    $node = new \TYPO3\Surf\Domain\Model\Node('example');
    $node->setHostname('example.com');
+   $node->setDeploymentPath('/home/my-flow-app/app');
    $node->setOption('username', 'myuser');
 
    $application = new \TYPO3\Surf\Application\Neos\Flow();
    $application->setVersion('4.0');
-   $application->setDeploymentPath('/home/my-flow-app/app');
    $application->setOption('repositoryUrl', 'git@github.com:myuser/my-flow-app.git');
    $application->addNode($node);
 
@@ -35,7 +35,9 @@ with name **MyDeployment**::
 That's a very basic deployment based on the default Flow application template ``TYPO3\Surf\Application\Neos\Flow``.
 The deployment object is available to the script as the variable ``$deployment``. A *node* is basically a deployment
 target representing a server for an application. The node is assigned to the applications for the deployment. Finally
-the application is added to the deployment.
+the application is added to the deployment. Depending on the usecase, the deployment path can also be set in the application
+object which is then set for all nodes. This is especially useful if you have several applications which you want to deploy
+to the same node for example a backend and frontend application.
 
 Each application resembles a repository with code. So a more complex deployment could both deploy a Flow application
 and release an extension for a TYPO3 CMS website. Also different roles can be expressed using applications, since every

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
         "phpstan": "phpstan analyse",
         "php-cs-fixer": "vendor/bin/php-cs-fixer fix --diff",
         "check-style": "vendor/bin/phpcs -p --standard=ruleset.xml --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
-        "fix-style": "vendor/bin/phpcbf -p --standard=ruleset.xml --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
+        "fix-style": "vendor/bin/phpcbf -p --standard=ruleset.xml --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/src/Application/BaseApplication.php
+++ b/src/Application/BaseApplication.php
@@ -183,7 +183,7 @@ class BaseApplication extends Application
 
     protected function registerTasksForPackageMethod(Workflow $workflow, ?string $packageMethod): void
     {
-        if ($packageMethod == 'git') {
+        if ($packageMethod === 'git') {
             $workflow->addTask(GitTask::class, SimpleWorkflowStage::STEP_03_PACKAGE, $this);
             $workflow->defineTask(
                 $localInstallTask = 'TYPO3\\Surf\\DefinedTask\\Composer\\LocalInstallTask',
@@ -215,5 +215,8 @@ class BaseApplication extends Application
 
     protected function registerTasksForUpdateMethod(Workflow $workflow, string $updateMethod): void
     {
+        if ($updateMethod === 'composer') {
+            $workflow->addTask(InstallTask::class, SimpleWorkflowStage::STEP_05_UPDATE, $this);
+        }
     }
 }

--- a/src/Application/Neos/Flow.php
+++ b/src/Application/Neos/Flow.php
@@ -15,7 +15,6 @@ use TYPO3\Surf\Application\BaseApplication;
 use TYPO3\Surf\Domain\Enum\SimpleWorkflowStage;
 use TYPO3\Surf\Domain\Model\Deployment;
 use TYPO3\Surf\Domain\Model\Workflow;
-use TYPO3\Surf\Task\Composer\InstallTask;
 use TYPO3\Surf\Task\Neos\Flow\CopyConfigurationTask;
 use TYPO3\Surf\Task\Neos\Flow\CreateDirectoriesTask;
 use TYPO3\Surf\Task\Neos\Flow\MigrateTask;
@@ -69,18 +68,6 @@ class Flow extends BaseApplication
         }
         if ($this->provideBoolOption('enableCacheWarmupAfterSwitchingToNewRelease')) {
             $workflow->afterTask(SymlinkReleaseTask::class, WarmUpCacheTask::class, $this);
-        }
-    }
-
-    protected function registerTasksForUpdateMethod(Workflow $workflow, string $updateMethod): void
-    {
-        switch ($updateMethod) {
-            case 'composer':
-                $workflow->addTask(InstallTask::class, SimpleWorkflowStage::STEP_05_UPDATE, $this);
-                break;
-            default:
-                parent::registerTasksForUpdateMethod($workflow, $updateMethod);
-                break;
         }
     }
 

--- a/src/Domain/Model/Application.php
+++ b/src/Domain/Model/Application.php
@@ -102,12 +102,24 @@ class Application
 
         $this->nodes = $nodes;
 
+        // If deployment path is set in application, set it for all nodes where path is not set
+        array_map(function (Node $node) {
+            if ($node->getDeploymentPath() === '') {
+                $node->setDeploymentPath($this->deploymentPath);
+            }
+        }, $this->nodes);
+
         return $this;
     }
 
     public function addNode(Node $node): self
     {
         $this->nodes[$node->getName()] = $node;
+
+        // If deployment path is set in application, set it for all nodes where path is not set
+        if ($node->getDeploymentPath() === '') {
+            $node->setDeploymentPath($this->deploymentPath);
+        }
 
         return $this;
     }
@@ -168,6 +180,13 @@ class Application
     public function setDeploymentPath(string $deploymentPath): self
     {
         $this->deploymentPath = rtrim($deploymentPath, '/');
+
+        // If deployment path is set in application, set it for all nodes where path is not set
+        array_map(function (Node $node) {
+            if ($node->getDeploymentPath() === '') {
+                $node->setDeploymentPath($this->deploymentPath);
+            }
+        }, $this->nodes);
 
         return $this;
     }

--- a/src/Domain/Model/Deployment.php
+++ b/src/Domain/Model/Deployment.php
@@ -21,8 +21,6 @@ use TYPO3\Surf\Exception as SurfException;
 use UnexpectedValueException;
 
 /**
- * A Deployment
- *
  * This is the base object exposed to a deployment configuration script and serves as a configuration builder and
  * model for an actual deployment.
  */
@@ -179,18 +177,18 @@ class Deployment implements LoggerAwareInterface, ContainerAwareInterface
         $this->getWorkflow()->run($this);
     }
 
-    public function getApplicationReleaseBasePath(Application $application): string
+    public function getApplicationReleaseBasePath(Node $node): string
     {
         return Files::concatenatePaths([
-            $application->getReleasesPath(),
+            $node->getReleasesPath(),
             $this->getReleaseIdentifier()
         ]);
     }
 
-    public function getApplicationReleasePath(Application $application): string
+    public function getApplicationReleasePath(Node $node): string
     {
         return Files::concatenatePaths([
-            $this->getApplicationReleaseBasePath($application),
+            $this->getApplicationReleaseBasePath($node),
             $this->relativeProjectRootPath
         ]);
     }

--- a/src/Domain/Model/Node.php
+++ b/src/Domain/Model/Node.php
@@ -11,12 +11,35 @@ declare(strict_types=1);
 
 namespace TYPO3\Surf\Domain\Model;
 
-/**
- * A Node
- */
+use TYPO3\Surf\Exception\InvalidConfigurationException;
+
 class Node
 {
+    /**
+     * default directory name for shared directory
+     *
+     * @const
+     */
+    public const DEFAULT_SHARED_DIR = 'shared';
+
+    private const FORBIDDEN_SHARED_REGULAR_EXPRESSION = '/(^|\/)\.\.(\/|$)/';
+
+    /**
+     * The name
+     */
     protected string $name;
+
+    /**
+     * The deployment path on the node
+     */
+    protected string $deploymentPath = '';
+
+    /**
+     * The relative releases directory on a node
+     *
+     * @var string
+     */
+    protected string $releasesDirectory = 'releases';
 
     /**
      * Options for this node
@@ -36,7 +59,81 @@ class Node
         return $this->name;
     }
 
-    public function getHostname(): string
+    public function getDeploymentPath(): string
+    {
+        return $this->deploymentPath;
+    }
+
+    public function setDeploymentPath(string $deploymentPath): self
+    {
+        $this->deploymentPath = $deploymentPath;
+        return $this;
+    }
+
+    public function getReleasesDirectory(): string
+    {
+        return $this->releasesDirectory;
+    }
+
+    public function setReleasesDirectory(string $releasesDirectory): self
+    {
+        if (preg_match(self::FORBIDDEN_SHARED_REGULAR_EXPRESSION, $releasesDirectory)) {
+            throw new InvalidConfigurationException(
+                sprintf('"../" is not allowed in the releases directory "%s"', $releasesDirectory),
+                1380870750
+            );
+        }
+        $this->releasesDirectory = trim($releasesDirectory, '/');
+        return $this;
+    }
+
+    /**
+     * Get the path for shared resources for this application
+     *
+     * This path defaults to a directory "shared" below the deployment path.
+     */
+    public function getSharedPath(): string
+    {
+        return $this->getDeploymentPath() . '/' . $this->getSharedDirectory();
+    }
+
+    /**
+     * Returns the shared directory
+     *
+     * takes directory name from option "sharedDirectory"
+     * if option is not set or empty constant DEFAULT_SHARED_DIR "shared" is used
+     */
+    public function getSharedDirectory(): string
+    {
+        $result = self::DEFAULT_SHARED_DIR;
+        if ($this->hasOption('sharedDirectory') && !empty($this->getOption('sharedDirectory'))) {
+            $sharedPath = $this->getOption('sharedDirectory');
+            if (preg_match(self::FORBIDDEN_SHARED_REGULAR_EXPRESSION, $sharedPath)) {
+                throw new InvalidConfigurationException(
+                    sprintf(
+                        'Relative constructs as "../" are not allowed in option "sharedDirectory". Given option: "%s"',
+                        $sharedPath
+                    ),
+                    1490107183141
+                );
+            }
+            $result = rtrim($sharedPath, '/');
+        }
+        return $result;
+    }
+
+    /**
+     * Returns path to the directory with releases
+     */
+    public function getReleasesPath(): string
+    {
+        return rtrim($this->getDeploymentPath() . '/' . $this->getReleasesDirectory(), '/');
+    }
+
+    /**
+     * Get the Node's hostname
+     */
+    public function getHostname(): ?string
     {
         return $this->getOption('hostname');
     }
@@ -48,7 +145,11 @@ class Node
 
     public function getOptions(): array
     {
-        return $this->options;
+        return array_merge($this->options, [
+            'deploymentPath' => $this->getDeploymentPath(),
+            'releasesPath' => $this->getReleasesPath(),
+            'sharedPath' => $this->getSharedPath()
+        ]);
     }
 
     public function setOptions(array $options): self
@@ -62,7 +163,16 @@ class Node
      */
     public function getOption(string $key)
     {
-        return $this->options[$key];
+        switch ($key) {
+            case 'deploymentPath':
+                return $this->getDeploymentPath();
+            case 'releasesPath':
+                return $this->getReleasesPath();
+            case 'sharedPath':
+                return $this->getSharedPath();
+            default:
+                return $this->options[$key];
+        }
     }
 
     /**
@@ -113,9 +223,6 @@ class Node
         return null;
     }
 
-    /**
-     * @return int|null
-     */
     public function getPort(): ?int
     {
         if ($this->hasOption('port')) {

--- a/src/Task/CleanupReleasesTask.php
+++ b/src/Task/CleanupReleasesTask.php
@@ -61,7 +61,7 @@ class CleanupReleasesTask extends Task implements ShellCommandServiceAwareInterf
             return;
         }
 
-        $releasesPath = $application->getReleasesPath();
+        $releasesPath = $node->getReleasesPath();
         $currentReleaseIdentifier = $deployment->getReleaseIdentifier();
 
         $previousReleaseIdentifier = findPreviousReleaseIdentifier($deployment, $node, $application, $this->shell);

--- a/src/Task/Composer/AbstractComposerTask.php
+++ b/src/Task/Composer/AbstractComposerTask.php
@@ -51,7 +51,7 @@ abstract class AbstractComposerTask extends Task implements ShellCommandServiceA
         if ($options['useApplicationWorkspace']) {
             $composerRootPath = $deployment->getWorkspaceWithProjectRootPath($application);
         } else {
-            $composerRootPath = $deployment->getApplicationReleasePath($application);
+            $composerRootPath = $deployment->getApplicationReleasePath($node);
         }
 
         if ($options['nodeName'] !== null) {

--- a/src/Task/Composer/DownloadTask.php
+++ b/src/Task/Composer/DownloadTask.php
@@ -41,7 +41,7 @@ class DownloadTask extends Task implements ShellCommandServiceAwareInterface
     {
         $options = $this->configureOptions($options);
 
-        $command = sprintf('cd %s && %s', escapeshellarg($deployment->getApplicationReleasePath($application)), $options['composerDownloadCommand']);
+        $command = sprintf('cd %s && %s', escapeshellarg($deployment->getApplicationReleasePath($node)), $options['composerDownloadCommand']);
 
         $this->shell->executeOrSimulate($command, $node, $deployment);
     }

--- a/src/Task/CreateArchiveTask.php
+++ b/src/Task/CreateArchiveTask.php
@@ -67,7 +67,7 @@ class CreateArchiveTask extends Task implements ShellCommandServiceAwareInterfac
         $options = $this->configureOptions($options);
 
         $this->shell->execute('rm -f ' . $options['targetFile'] . '; mkdir -p ' . dirname($options['targetFile']), $node, $deployment);
-        $sourcePath = $deployment->getApplicationReleasePath($application);
+        $sourcePath = $deployment->getApplicationReleasePath($node);
 
         $tarOptions = sprintf(' --transform="s,^%s,%s," ', ltrim($sourcePath, '/'), $options['baseDirectory']);
         foreach ($options['exclude'] as $excludePattern) {

--- a/src/Task/CreateDirectoriesTask.php
+++ b/src/Task/CreateDirectoriesTask.php
@@ -37,15 +37,15 @@ class CreateDirectoriesTask extends Task implements ShellCommandServiceAwareInte
 
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = []): void
     {
-        $result = $this->shell->execute(sprintf('test -d %s', $application->getDeploymentPath()), $node, $deployment, true);
+        $result = $this->shell->execute(sprintf('test -d %s', $node->getDeploymentPath()), $node, $deployment, true);
         if ($result === false) {
-            throw new TaskExecutionException('Deployment directory "' . $application->getDeploymentPath() . '" does not exist on node ' . $node->getName(), 1311003253);
+            throw new TaskExecutionException('Deployment directory "' . $node->getDeploymentPath() . '" does not exist on node ' . $node->getName(), 1311003253);
         }
         $commands = [
-            sprintf('mkdir -p %s', $application->getReleasesPath()),
-            sprintf('mkdir -p %s', $application->getSharedPath()),
-            sprintf('mkdir -p %s', $deployment->getApplicationReleasePath($application)),
-            sprintf('cd %s;ln -snf ./%s next', $application->getReleasesPath(), $deployment->getReleaseIdentifier())
+            sprintf('mkdir -p %s', $node->getReleasesPath()),
+            sprintf('mkdir -p %s', $node->getSharedPath()),
+            sprintf('mkdir -p %s', $deployment->getApplicationReleasePath($node)),
+            sprintf('cd %s;ln -snf ./%s next', $node->getReleasesPath(), $deployment->getReleaseIdentifier())
         ];
         $this->shell->executeOrSimulate($commands, $node, $deployment);
     }
@@ -61,8 +61,8 @@ class CreateDirectoriesTask extends Task implements ShellCommandServiceAwareInte
     public function rollback(Node $node, Application $application, Deployment $deployment, array $options = []): void
     {
         $commands = [
-            sprintf('rm %s/next', $application->getReleasesPath()),
-            sprintf('rm -rf %s', $deployment->getApplicationReleasePath($application))
+            sprintf('rm %s/next', $node->getReleasesPath()),
+            sprintf('rm -rf %s', $deployment->getApplicationReleasePath($node))
         ];
         $this->shell->execute($commands, $node, $deployment, true);
     }

--- a/src/Task/Generic/CreateDirectoriesTask.php
+++ b/src/Task/Generic/CreateDirectoriesTask.php
@@ -56,7 +56,7 @@ class CreateDirectoriesTask extends Task implements ShellCommandServiceAwareInte
             return;
         }
 
-        $baseDirectory = $options['baseDirectory'] ?: $deployment->getApplicationReleasePath($application);
+        $baseDirectory = $options['baseDirectory'] ?: $deployment->getApplicationReleasePath($node);
 
         $commands = array_map(fn ($directory): string => sprintf('mkdir -p %s', $directory), $options['directories']);
 

--- a/src/Task/Generic/CreateSymlinksTask.php
+++ b/src/Task/Generic/CreateSymlinksTask.php
@@ -46,7 +46,7 @@ class CreateSymlinksTask extends Task implements ShellCommandServiceAwareInterfa
             return;
         }
 
-        $baseDirectory = $options['genericSymlinksBaseDir'] ?: $deployment->getApplicationReleasePath($application);
+        $baseDirectory = $options['genericSymlinksBaseDir'] ?: $deployment->getApplicationReleasePath($node);
 
         $commands = [
             'cd ' . $baseDirectory,

--- a/src/Task/Generic/RollbackTask.php
+++ b/src/Task/Generic/RollbackTask.php
@@ -29,7 +29,7 @@ final class RollbackTask extends Task implements ShellCommandServiceAwareInterfa
     {
         $allReleases = findAllReleases($deployment, $node, $application, $this->shell);
 
-        $releasesPath = $application->getReleasesPath();
+        $releasesPath = $node->getReleasesPath();
 
         $releases = array_map('trim', array_filter($allReleases, fn ($release): bool => $release !== '.' && $release !== 'current' && $release !== 'previous'));
 
@@ -60,7 +60,7 @@ final class RollbackTask extends Task implements ShellCommandServiceAwareInterfa
                 $this->shell->executeOrSimulate($symlinkCommand, $node, $deployment);
             } else {
                 // Remove previous symlink
-                $removeCommand = sprintf('rm -rf %1$s/previous', $application->getReleasesPath());
+                $removeCommand = sprintf('rm -rf %1$s/previous', $node->getReleasesPath());
                 $deployment->getLogger()->info(($deployment->isDryRun() ? 'Would remove' : 'Removing') . ' previous symlink: ' . $removeCommand);
                 $this->shell->executeOrSimulate($removeCommand, $node, $deployment);
             }

--- a/src/Task/Git/PushTask.php
+++ b/src/Task/Git/PushTask.php
@@ -45,7 +45,7 @@ class PushTask extends Task implements ShellCommandServiceAwareInterface
     {
         $options = $this->configureOptions($options);
 
-        $targetPath = $deployment->getApplicationReleasePath($application);
+        $targetPath = $deployment->getApplicationReleasePath($node);
 
         $this->shell->executeOrSimulate(sprintf('cd ' . $targetPath . '; git push -f %s %s', $options['remote'], $options['refspec']), $node, $deployment);
         if ($options['recurseIntoSubmodules']) {

--- a/src/Task/Git/TagTask.php
+++ b/src/Task/Git/TagTask.php
@@ -49,7 +49,7 @@ class TagTask extends Task implements ShellCommandServiceAwareInterface
         $this->validateOptions($options);
         $options = $this->processOptions($options, $deployment);
 
-        $targetPath = $deployment->getApplicationReleasePath($application);
+        $targetPath = $deployment->getApplicationReleasePath($node);
         $this->shell->executeOrSimulate(sprintf('cd ' . $targetPath . '; git tag -f -a -m %s %s', escapeshellarg($options['description']), escapeshellarg($options['tagName'])), $node, $deployment);
         if (isset($options['recurseIntoSubmodules']) && $options['recurseIntoSubmodules'] === true) {
             $submoduleCommand = escapeshellarg(sprintf('git tag -f -a -m %s %s', escapeshellarg($options['description']), escapeshellarg($options['submoduleTagNamePrefix'] . $options['tagName'])));

--- a/src/Task/GitCheckoutTask.php
+++ b/src/Task/GitCheckoutTask.php
@@ -35,8 +35,8 @@ class GitCheckoutTask extends AbstractCheckoutTask
     {
         $options = $this->configureOptions($options);
 
-        $releasePath = $deployment->getApplicationReleasePath($application);
-        $checkoutPath = Files::concatenatePaths([$application->getDeploymentPath(), 'cache/transfer']);
+        $releasePath = $deployment->getApplicationReleasePath($node);
+        $checkoutPath = Files::concatenatePaths([$node->getDeploymentPath(), 'cache', 'transfer']);
 
         $sha1 = $this->executeOrSimulateGitCloneOrUpdate($checkoutPath, $node, $deployment, $options);
 
@@ -52,7 +52,7 @@ class GitCheckoutTask extends AbstractCheckoutTask
 
     public function rollback(Node $node, Application $application, Deployment $deployment, array $options = []): void
     {
-        $releasePath = $deployment->getApplicationReleasePath($application);
+        $releasePath = $deployment->getApplicationReleasePath($node);
         $this->shell->execute('rm -f ' . $releasePath . 'REVISION', $node, $deployment, true);
     }
 

--- a/src/Task/Laravel/AbstractCliTask.php
+++ b/src/Task/Laravel/AbstractCliTask.php
@@ -96,7 +96,7 @@ abstract class AbstractCliTask extends Task implements ShellCommandServiceAwareI
                 $this->workingDirectory = $deployment->getWorkspacePath($application);
                 $node = $deployment->createLocalhostNode();
             } else {
-                $this->workingDirectory = $deployment->getApplicationReleasePath($application);
+                $this->workingDirectory = $deployment->getApplicationReleasePath($node);
             }
             $this->targetNode = $node;
         }

--- a/src/Task/Laravel/CreateDirectoriesTask.php
+++ b/src/Task/Laravel/CreateDirectoriesTask.php
@@ -27,7 +27,7 @@ class CreateDirectoriesTask extends \TYPO3\Surf\Task\Generic\CreateDirectoriesTa
                 'shared/storage/framework/testing',
                 'shared/storage/framework/views',
             ],
-            'baseDirectory' => $application->getDeploymentPath()
+            'baseDirectory' => $node->getDeploymentPath()
         ];
         parent::execute($node, $application, $deployment, $options);
     }

--- a/src/Task/Laravel/EnvAwareTask.php
+++ b/src/Task/Laravel/EnvAwareTask.php
@@ -35,8 +35,8 @@ class EnvAwareTask extends Task implements ShellCommandServiceAwareInterface
      */
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = [])
     {
-        $sharedPath = $application->getSharedPath();
-        $releasePath = $deployment->getApplicationReleasePath($application);
+        $sharedPath = $node->getSharedPath();
+        $releasePath = $deployment->getApplicationReleasePath($node);
 
         $result = $this->shell->execute(sprintf('test -f %s/.env', $sharedPath), $node, $deployment, true);
         if ($result === false) {

--- a/src/Task/Laravel/SymlinkStorageTask.php
+++ b/src/Task/Laravel/SymlinkStorageTask.php
@@ -28,10 +28,10 @@ class SymlinkStorageTask extends Task implements ShellCommandServiceAwareInterfa
 
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = [])
     {
-        $targetReleasePath = $deployment->getApplicationReleasePath($application);
+        $targetReleasePath = $deployment->getApplicationReleasePath($node);
 
-        $deploymentPath = $application->getDeploymentPath();
-        $applicationReleasePath = $deployment->getApplicationReleasePath($application);
+        $deploymentPath = $node->getDeploymentPath();
+        $applicationReleasePath = $deployment->getApplicationReleasePath($node);
         $diffPath = substr($applicationReleasePath, strlen($deploymentPath));
 
         $relativeDataPath = str_repeat('../', substr_count(trim($diffPath, '/'), '/') + 1) . 'shared';

--- a/src/Task/LockDeploymentTask.php
+++ b/src/Task/LockDeploymentTask.php
@@ -39,11 +39,11 @@ final class LockDeploymentTask extends Task implements ShellCommandServiceAwareI
     {
         if (! $deployment->isDryRun()) {
             // Create .surf directory if not exists
-            $lockDirectory = escapeshellarg($application->getDeploymentPath() . '/.surf');
+            $lockDirectory = escapeshellarg($node->getDeploymentPath() . '/.surf');
             $this->shell->execute(sprintf('[ -d %1$s ] || mkdir %1$s', $lockDirectory), $node, $deployment);
         }
 
-        $deploymentLockFile = escapeshellarg(sprintf('%s/.surf/%s', $application->getDeploymentPath(), self::LOCK_FILE_NAME));
+        $deploymentLockFile = escapeshellarg(sprintf('%s/.surf/%s', $node->getDeploymentPath(), self::LOCK_FILE_NAME));
         $locked = (bool)$this->shell->execute(sprintf('if [ -f %s ]; then echo 1; else echo 0; fi', $deploymentLockFile), $node, $deployment);
         if ($locked) {
             $currentDeploymentLockIdentifier = $this->shell->execute(sprintf('cat %s', $deploymentLockFile), $node, $deployment);

--- a/src/Task/Neos/Flow/CopyConfigurationTask.php
+++ b/src/Task/Neos/Flow/CopyConfigurationTask.php
@@ -41,7 +41,7 @@ class CopyConfigurationTask extends Task implements ShellCommandServiceAwareInte
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = []): void
     {
         $configurationFileExtension = $options['configurationFileExtension'] ?? 'yaml';
-        $targetReleasePath = $deployment->getApplicationReleasePath($application);
+        $targetReleasePath = $deployment->getApplicationReleasePath($node);
         $configurationPath = $deployment->getDeploymentConfigurationPath();
         if (!is_dir($configurationPath)) {
             return;

--- a/src/Task/Neos/Flow/CreateDirectoriesTask.php
+++ b/src/Task/Neos/Flow/CreateDirectoriesTask.php
@@ -30,7 +30,7 @@ class CreateDirectoriesTask extends \TYPO3\Surf\Task\Generic\CreateDirectoriesTa
                 'shared/Data/Persistent',
                 'shared/Configuration'
             ],
-            'baseDirectory' => $application->getDeploymentPath()
+            'baseDirectory' => $node->getDeploymentPath()
         ];
         parent::execute($node, $application, $deployment, $options);
     }

--- a/src/Task/Neos/Flow/FlushCacheListTask.php
+++ b/src/Task/Neos/Flow/FlushCacheListTask.php
@@ -52,7 +52,7 @@ class FlushCacheListTask extends Task implements ShellCommandServiceAwareInterfa
 
         $options = $this->configureOptions($options);
 
-        $targetPath = $deployment->getApplicationReleasePath($application);
+        $targetPath = $deployment->getApplicationReleasePath($node);
 
         foreach ($options['flushCacheList'] as $cache) {
             $deployment->getLogger()->debug(sprintf('Flush cache with identifier "%s"', $cache));

--- a/src/Task/Neos/Flow/FunctionalTestTask.php
+++ b/src/Task/Neos/Flow/FunctionalTestTask.php
@@ -33,7 +33,7 @@ class FunctionalTestTask extends Task implements ShellCommandServiceAwareInterfa
     {
         Assert::isInstanceOf($application, Flow::class, sprintf('Flow application needed for FunctionalTestTask, got "%s"', get_class($application)));
 
-        $targetPath = $deployment->getApplicationReleasePath($application);
+        $targetPath = $deployment->getApplicationReleasePath($node);
 
         $command = sprintf('cd %s && phpunit -c Build/%s/PhpUnit/FunctionalTests.xml', $targetPath, $application->getBuildEssentialsDirectoryName());
 

--- a/src/Task/Neos/Flow/MigrateTask.php
+++ b/src/Task/Neos/Flow/MigrateTask.php
@@ -37,7 +37,7 @@ class MigrateTask extends Task implements ShellCommandServiceAwareInterface
         Assert::isInstanceOf($application, Flow::class, sprintf('Flow application needed for MigrateTask, got "%s"', get_class($application)));
         $options = $this->configureOptions($options);
 
-        $targetPath = $deployment->getApplicationReleasePath($application);
+        $targetPath = $deployment->getApplicationReleasePath($node);
         $this->shell->executeOrSimulate($application->buildCommand($targetPath, 'doctrine:migrate', [], $options['phpBinaryPathAndFilename']), $node, $deployment);
     }
 

--- a/src/Task/Neos/Flow/PublishResourcesTask.php
+++ b/src/Task/Neos/Flow/PublishResourcesTask.php
@@ -38,7 +38,7 @@ class PublishResourcesTask extends Task implements ShellCommandServiceAwareInter
         $options = $this->configureOptions($options);
 
         if ($application->getVersion() >= '3.0') {
-            $targetPath = $deployment->getApplicationReleasePath($application);
+            $targetPath = $deployment->getApplicationReleasePath($node);
             $this->shell->executeOrSimulate($application->buildCommand($targetPath, 'resource:publish', [], $options['phpBinaryPathAndFilename']), $node, $deployment);
         }
     }

--- a/src/Task/Neos/Flow/RunCommandTask.php
+++ b/src/Task/Neos/Flow/RunCommandTask.php
@@ -54,7 +54,7 @@ class RunCommandTask extends Task implements ShellCommandServiceAwareInterface
 
         $options = $this->configureOptions($options);
 
-        $targetPath = $deployment->getApplicationReleasePath($application);
+        $targetPath = $deployment->getApplicationReleasePath($node);
 
         $command = $application->buildCommand($targetPath, $options['command'], $options['arguments'], $options['phpBinaryPathAndFilename']);
 

--- a/src/Task/Neos/Flow/SetFilePermissionsTask.php
+++ b/src/Task/Neos/Flow/SetFilePermissionsTask.php
@@ -50,7 +50,7 @@ class SetFilePermissionsTask extends Task implements ShellCommandServiceAwareInt
     {
         Assert::isInstanceOf($application, Flow::class, sprintf('Flow application needed for SetFilePermissionsTask, got "%s"', get_class($application)));
 
-        $targetPath = $deployment->getApplicationReleasePath($application);
+        $targetPath = $deployment->getApplicationReleasePath($node);
 
         $options = $this->configureOptions($options);
 

--- a/src/Task/Neos/Flow/SymlinkConfigurationTask.php
+++ b/src/Task/Neos/Flow/SymlinkConfigurationTask.php
@@ -35,7 +35,7 @@ class SymlinkConfigurationTask extends Task implements ShellCommandServiceAwareI
 
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = []): void
     {
-        $targetReleasePath = $deployment->getApplicationReleasePath($application);
+        $targetReleasePath = $deployment->getApplicationReleasePath($node);
 
         $context = $application instanceof Flow ? $application->getContext() : 'Production';
 

--- a/src/Task/Neos/Flow/SymlinkDataTask.php
+++ b/src/Task/Neos/Flow/SymlinkDataTask.php
@@ -30,7 +30,7 @@ class SymlinkDataTask extends Task implements ShellCommandServiceAwareInterface
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = []): void
     {
         $releaseIdentifier = $deployment->getReleaseIdentifier();
-        $releasesPath = $application->getReleasesPath();
+        $releasesPath = $node->getReleasesPath();
         $commands = [
             "mkdir -p $releasesPath/$releaseIdentifier/Data",
             "cd $releasesPath/$releaseIdentifier",

--- a/src/Task/Neos/Flow/UnitTestTask.php
+++ b/src/Task/Neos/Flow/UnitTestTask.php
@@ -33,7 +33,7 @@ class UnitTestTask extends Task implements ShellCommandServiceAwareInterface
     {
         Assert::isInstanceOf($application, Flow::class, sprintf('Flow application needed for UnitTestTask, got "%s"', get_class($application)));
 
-        $targetPath = $deployment->getApplicationReleasePath($application);
+        $targetPath = $deployment->getApplicationReleasePath($node);
         $this->shell->executeOrSimulate('cd ' . $targetPath . ' && phpunit -c Build/' . $application->getBuildEssentialsDirectoryName() . '/PhpUnit/UnitTests.xml', $node, $deployment);
     }
 

--- a/src/Task/Neos/Flow/WarmUpCacheTask.php
+++ b/src/Task/Neos/Flow/WarmUpCacheTask.php
@@ -38,7 +38,7 @@ class WarmUpCacheTask extends Task implements ShellCommandServiceAwareInterface
 
         $options = $this->configureOptions($options);
 
-        $targetPath = $deployment->getApplicationReleasePath($application);
+        $targetPath = $deployment->getApplicationReleasePath($node);
 
         $this->shell->executeOrSimulate(
             $application->buildCommand($targetPath, 'cache:warmup', [], $options['phpBinaryPathAndFilename']),

--- a/src/Task/Neos/Neos/ImportSiteTask.php
+++ b/src/Task/Neos/Neos/ImportSiteTask.php
@@ -48,7 +48,7 @@ class ImportSiteTask extends Task implements ShellCommandServiceAwareInterface
 
         $options = $this->configureOptions($options);
 
-        $targetPath = $deployment->getApplicationReleasePath($application);
+        $targetPath = $deployment->getApplicationReleasePath($node);
         $arguments = [
             '--package-key',
             $options['sitePackageKey']

--- a/src/Task/RsyncFoldersTask.php
+++ b/src/Task/RsyncFoldersTask.php
@@ -56,11 +56,11 @@ class RsyncFoldersTask extends Task implements ShellCommandServiceAwareInterface
         }
 
         $replacePaths = [
-            '{deploymentPath}' => escapeshellarg($application->getDeploymentPath()),
-            '{sharedPath}' => escapeshellarg($application->getSharedPath()),
-            '{releasePath}' => escapeshellarg($deployment->getApplicationReleasePath($application)),
-            '{currentPath}' => escapeshellarg($application->getReleasesPath() . '/current'),
-            '{previousPath}' => escapeshellarg($application->getReleasesPath() . '/previous'),
+            '{deploymentPath}' => escapeshellarg($node->getDeploymentPath()),
+            '{sharedPath}' => escapeshellarg($node->getSharedPath()),
+            '{releasePath}' => escapeshellarg($deployment->getApplicationReleasePath($node)),
+            '{currentPath}' => escapeshellarg($node->getReleasesPath() . '/current'),
+            '{previousPath}' => escapeshellarg($node->getReleasesPath() . '/previous'),
         ];
 
         // Build commands to transfer folders

--- a/src/Task/ShellTask.php
+++ b/src/Task/ShellTask.php
@@ -44,7 +44,7 @@ class ShellTask extends Task implements ShellCommandServiceAwareInterface
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = []): void
     {
         $options = $this->configureOptions($options);
-        $command = $this->replacePaths($application, $deployment, $options['command']);
+        $command = $this->replacePaths($node, $application, $deployment, $options['command']);
         $this->shell->executeOrSimulate($command, $node, $deployment, $options['ignoreErrors'], $options['logOutput']);
     }
 
@@ -64,7 +64,7 @@ class ShellTask extends Task implements ShellCommandServiceAwareInterface
             return;
         }
 
-        $command = $this->replacePaths($application, $deployment, $options['rollbackCommand']);
+        $command = $this->replacePaths($node, $application, $deployment, $options['rollbackCommand']);
         $this->shell->execute($command, $node, $deployment, true);
     }
 
@@ -77,19 +77,20 @@ class ShellTask extends Task implements ShellCommandServiceAwareInterface
     }
 
     /**
+     * @param Node $node
      * @param Application $application
      * @param Deployment $deployment
      * @param array|string|string[] $command
      * @return array|string|string[]
      */
-    private function replacePaths(Application $application, Deployment $deployment, $command)
+    private function replacePaths(Node $node, Application $application, Deployment $deployment, $command)
     {
         $replacePaths = [
-            '{deploymentPath}' => escapeshellarg($application->getDeploymentPath()),
-            '{sharedPath}' => escapeshellarg($application->getSharedPath()),
-            '{releasePath}' => escapeshellarg($deployment->getApplicationReleasePath($application)),
-            '{currentPath}' => escapeshellarg($application->getReleasesPath() . '/current'),
-            '{previousPath}' => escapeshellarg($application->getReleasesPath() . '/previous'),
+            '{deploymentPath}' => escapeshellarg($node->getDeploymentPath()),
+            '{sharedPath}' => escapeshellarg($node->getSharedPath()),
+            '{releasePath}' => escapeshellarg($deployment->getApplicationReleasePath($node)),
+            '{currentPath}' => escapeshellarg($node->getReleasesPath() . '/current'),
+            '{previousPath}' => escapeshellarg($node->getReleasesPath() . '/previous'),
         ];
 
         return str_replace(array_keys($replacePaths), $replacePaths, $command);

--- a/src/Task/SymlinkReleaseTask.php
+++ b/src/Task/SymlinkReleaseTask.php
@@ -31,7 +31,7 @@ class SymlinkReleaseTask extends Task implements ShellCommandServiceAwareInterfa
     {
         $command = sprintf(
             'cd %s && rm -rf ./previous && if [ -e ./current ]; then mv ./current ./previous; fi && ln -s ./%s ./current && rm -rf ./next',
-            $application->getReleasesPath(),
+            $node->getReleasesPath(),
             $deployment->getReleaseIdentifier()
         );
 
@@ -49,7 +49,7 @@ class SymlinkReleaseTask extends Task implements ShellCommandServiceAwareInterfa
 
     public function rollback(Node $node, Application $application, Deployment $deployment, array $options = []): void
     {
-        $command = sprintf('cd %s && rm -f ./current && mv ./previous ./current', $application->getReleasesPath());
+        $command = sprintf('cd %s && rm -f ./current && mv ./previous ./current', $node->getReleasesPath());
 
         $this->shell->execute($command, $node, $deployment, true);
     }

--- a/src/Task/TYPO3/CMS/AbstractCliTask.php
+++ b/src/Task/TYPO3/CMS/AbstractCliTask.php
@@ -74,7 +74,7 @@ abstract class AbstractCliTask extends Task implements ShellCommandServiceAwareI
                 $this->workingDirectory = $deployment->getWorkspacePath($application);
                 $node = $deployment->createLocalhostNode();
             } else {
-                $this->workingDirectory = $deployment->getApplicationReleasePath($application);
+                $this->workingDirectory = $deployment->getApplicationReleasePath($node);
             }
             $this->targetNode = $node;
         }

--- a/src/Task/TYPO3/CMS/SymlinkDataTask.php
+++ b/src/Task/TYPO3/CMS/SymlinkDataTask.php
@@ -33,7 +33,7 @@ class SymlinkDataTask extends Task implements ShellCommandServiceAwareInterface
     {
         $commands = [];
         $options = $this->configureOptions($options);
-        $targetReleasePath = $deployment->getApplicationReleasePath($application);
+        $targetReleasePath = $deployment->getApplicationReleasePath($node);
         $webDirectory = $options['webDirectory'];
         $relativeDataPath = $relativeDataPathFromWeb = '../../shared/Data';
         if ($webDirectory !== '') {

--- a/src/Task/Transfer/RsyncTask.php
+++ b/src/Task/Transfer/RsyncTask.php
@@ -38,13 +38,13 @@ class RsyncTask extends Task implements ShellCommandServiceAwareInterface
         $options = $this->configureOptions($options);
 
         $localPackagePath = $deployment->getWorkspacePath($application);
-        $releasePath = $deployment->getApplicationReleaseBasePath($application);
+        $releasePath = $deployment->getApplicationReleaseBasePath($node);
 
         if ($options['webDirectory'] !== null) {
             $this->replacePaths['{webDirectory}'] = $options['webDirectory'];
         }
 
-        $remotePath = Files::concatenatePaths([$application->getDeploymentPath(), 'cache/transfer']);
+        $remotePath = Files::concatenatePaths([$node->getDeploymentPath(), 'cache', 'transfer']);
         // make sure there is a remote .cache folder
         $command = 'mkdir -p ' . $remotePath;
         $this->shell->executeOrSimulate($command, $node, $deployment);
@@ -94,7 +94,7 @@ class RsyncTask extends Task implements ShellCommandServiceAwareInterface
 
     public function rollback(Node $node, Application $application, Deployment $deployment, array $options = []): void
     {
-        $releasePath = $deployment->getApplicationReleasePath($application);
+        $releasePath = $deployment->getApplicationReleasePath($node);
         $this->shell->execute('rm -Rf ' . $releasePath, $node, $deployment, true);
     }
 

--- a/src/Task/Transfer/ScpTask.php
+++ b/src/Task/Transfer/ScpTask.php
@@ -34,10 +34,10 @@ final class ScpTask extends Task implements ShellCommandServiceAwareInterface
         $fileName = sprintf('%s.tar.gz', $deployment->getReleaseIdentifier());
 
         $localPackagePath = $deployment->getWorkspacePath($application);
-        $releasePath = Files::concatenatePaths([$application->getReleasesPath(), $deployment->getReleaseIdentifier()]);
+        $releasePath = Files::concatenatePaths([$node->getReleasesPath(), $deployment->getReleaseIdentifier()]);
 
         // Create remote transfer path if not exist
-        $remoteTransferPath = Files::concatenatePaths([$application->getDeploymentPath(), 'cache', SimpleWorkflowStage::STEP_04_TRANSFER]);
+        $remoteTransferPath = Files::concatenatePaths([$node->getDeploymentPath(), 'cache', SimpleWorkflowStage::STEP_04_TRANSFER]);
         $this->shell->executeOrSimulate(sprintf('mkdir -p %s', $remoteTransferPath), $node, $deployment);
 
         // Create the scp destination command
@@ -104,7 +104,7 @@ final class ScpTask extends Task implements ShellCommandServiceAwareInterface
 
     public function rollback(Node $node, Application $application, Deployment $deployment, array $options = []): void
     {
-        $releasePath = $deployment->getApplicationReleasePath($application);
+        $releasePath = $deployment->getApplicationReleasePath($node);
         $this->shell->execute(sprintf('rm -rf %s', $releasePath), $node, $deployment, true);
     }
 

--- a/src/Task/UnlockDeploymentTask.php
+++ b/src/Task/UnlockDeploymentTask.php
@@ -24,7 +24,7 @@ final class UnlockDeploymentTask extends Task implements ShellCommandServiceAwar
 
     public function execute(Node $node, Application $application, Deployment $deployment, array $options = []): void
     {
-        $deploymentLockFile = escapeshellarg(sprintf('%s/.surf/%s', $application->getDeploymentPath(), LockDeploymentTask::LOCK_FILE_NAME));
+        $deploymentLockFile = escapeshellarg(sprintf('%s/.surf/%s', $node->getDeploymentPath(), LockDeploymentTask::LOCK_FILE_NAME));
 
         if (!$deployment->isDryRun()) {
             $rmOptions = $deployment->getForceRun() ? ' -f' : '';

--- a/src/functions.php
+++ b/src/functions.php
@@ -23,7 +23,7 @@ use TYPO3\Surf\Domain\Service\ShellCommandService;
  */
 function findAllReleases(Deployment $deployment, Node $node, Application $application, ShellCommandService $shell): array
 {
-    $releasesPath = $application->getReleasesPath();
+    $releasesPath = $node->getReleasesPath();
     $allReleasesList = $shell->execute("if [ -d $releasesPath/. ]; then find $releasesPath/. -maxdepth 1 -type d -exec basename {} \; ; fi", $node, $deployment);
 
     $allReleases = preg_split('/\s+/', $allReleasesList, -1, PREG_SPLIT_NO_EMPTY);
@@ -40,7 +40,7 @@ function findAllReleases(Deployment $deployment, Node $node, Application $applic
  */
 function findPreviousReleaseIdentifier(Deployment $deployment, Node $node, Application $application, ShellCommandService $shell): string
 {
-    $previousReleasePath = $application->getReleasesPath() . '/previous';
+    $previousReleasePath = $node->getReleasesPath() . '/previous';
     return trim($shell->execute("if [ -h $previousReleasePath ]; then basename `readlink $previousReleasePath` ; fi", $node, $deployment) ?? '');
 }
 
@@ -49,6 +49,6 @@ function findPreviousReleaseIdentifier(Deployment $deployment, Node $node, Appli
  */
 function findCurrentReleaseIdentifier(Deployment $deployment, Node $node, Application $application, ShellCommandService $shell): string
 {
-    $currentReleasePath = $application->getReleasesPath() . '/current';
+    $currentReleasePath = $node->getReleasesPath() . '/current';
     return trim($shell->execute("if [ -h $currentReleasePath ]; then basename `readlink $currentReleasePath` ; fi", $node, $deployment));
 }

--- a/tests/Unit/Domain/Model/DeploymentTest.php
+++ b/tests/Unit/Domain/Model/DeploymentTest.php
@@ -148,14 +148,14 @@ class DeploymentTest extends TestCase
     {
         $deployment = new Deployment('Some name');
 
-        $application = new Application('Test application 1');
-        $application->setDeploymentPath('/deployment/path');
+        $node = new Node('Node');
+        $node->setDeploymentPath('/deployment/path');
 
         $releaseIdentifier = $deployment->getReleaseIdentifier();
 
         self::assertSame(
             '/deployment/path/releases/' . $releaseIdentifier,
-            $deployment->getApplicationReleasePath($application)
+            $deployment->getApplicationReleasePath($node)
         );
     }
 
@@ -167,14 +167,14 @@ class DeploymentTest extends TestCase
         $deployment = new Deployment('Some name');
         $deployment->setRelativeProjectRootPath('htdocs');
 
-        $application = new Application('Test application 1');
-        $application->setDeploymentPath('/deployment/path');
+        $node = new Node('Node');
+        $node->setDeploymentPath('/deployment/path');
 
         $releaseIdentifier = $deployment->getReleaseIdentifier();
 
         self::assertSame(
             '/deployment/path/releases/' . $releaseIdentifier . '/htdocs',
-            $deployment->getApplicationReleasePath($application)
+            $deployment->getApplicationReleasePath($node)
         );
     }
 

--- a/tests/Unit/Domain/Model/NodeTest.php
+++ b/tests/Unit/Domain/Model/NodeTest.php
@@ -13,6 +13,7 @@ namespace TYPO3\Surf\Tests\Unit\Domain\Model;
 
 use PHPUnit\Framework\TestCase;
 use TYPO3\Surf\Domain\Model\Node;
+use TYPO3\Surf\Exception\InvalidConfigurationException;
 
 class NodeTest extends TestCase
 {
@@ -47,5 +48,48 @@ class NodeTest extends TestCase
         $node->setUsername('username');
 
         self::assertSame('username', $node->getUsername());
+    }
+
+    /**
+     * The directory for shared assets is by default 'shared'
+     *
+     * @test
+     * @throws InvalidConfigurationException
+     */
+    public function getSharedDirectoryReturnsDefaultIfNoOptionsGiven(): void
+    {
+        $node = new Node('Node');
+
+        self::assertEquals('shared', $node->getSharedDirectory());
+    }
+
+    /**
+     * If option 'sharedDirectory' is configured we expect this to be returned
+     * by getSharedDirectory
+     *
+     * @test
+     * @throws InvalidConfigurationException
+     */
+    public function getSharedDirectoryReturnsContentOfOptionIfConfigured(): void
+    {
+        $node = new Node('Node');
+        $node->setOption('sharedDirectory', 'sharedAssets');
+
+        self::assertEquals('sharedAssets', $node->getSharedDirectory());
+    }
+
+    /**
+     * Relative paths are not allowed as sharedDirectory
+     * we expect an exception on relative Paths
+     *
+     * @test
+     */
+    public function getSharedDirectoryThrowsExceptionOnRelativePaths(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $node = new Node('Node');
+        $node->setOption('sharedDirectory', '../sharedAssets');
+        $node->getSharedDirectory();
     }
 }

--- a/tests/Unit/Task/CleanupReleasesTaskTest.php
+++ b/tests/Unit/Task/CleanupReleasesTaskTest.php
@@ -110,7 +110,7 @@ class CleanupReleasesTaskTest extends BaseTaskTest
             ['20171108132211', '20171109193135'],
             fn ($carry, $folder): string => $carry . sprintf(
                 'rm -rf %1$s/%2$s;rm -f %1$s/%2$sREVISION;',
-                $this->application->getReleasesPath(),
+                $this->node->getReleasesPath(),
                 $folder
             ),
             ''
@@ -159,7 +159,7 @@ class CleanupReleasesTaskTest extends BaseTaskTest
             ),
             fn ($command, $folder): string => $command . sprintf(
                 'rm -rf %1$s/%2$s;rm -f %1$s/%2$sREVISION;',
-                $this->application->getReleasesPath(),
+                $this->node->getReleasesPath(),
                 $folder
             ),
             ''

--- a/tests/Unit/Task/Composer/CommandTaskTest.php
+++ b/tests/Unit/Task/Composer/CommandTaskTest.php
@@ -21,7 +21,7 @@ class CommandTaskTest extends BaseTaskTest
     {
         parent::setUp();
 
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): CommandTask

--- a/tests/Unit/Task/Composer/DownloadTaskTest.php
+++ b/tests/Unit/Task/Composer/DownloadTaskTest.php
@@ -26,7 +26,7 @@ class DownloadTaskTest extends BaseTaskTest
      */
     public function executeWithDefaultComposerDownloadCommand(): void
     {
-        $applicationReleasePath = $this->deployment->getApplicationReleasePath($this->application);
+        $applicationReleasePath = $this->deployment->getApplicationReleasePath($this->node);
         $this->task->execute($this->node, $this->application, $this->deployment, []);
         $this->assertCommandExecuted(sprintf('cd %s && %s', escapeshellarg($applicationReleasePath), 'curl -s https://getcomposer.org/installer | php'));
     }
@@ -36,7 +36,7 @@ class DownloadTaskTest extends BaseTaskTest
      */
     public function executeWithCustomComposerDownloadCommand(): void
     {
-        $applicationReleasePath = $this->deployment->getApplicationReleasePath($this->application);
+        $applicationReleasePath = $this->deployment->getApplicationReleasePath($this->node);
         $options = ['composerDownloadCommand' => 'curl -s https://custom.domain.org/installer | php'];
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
         $this->assertCommandExecuted(sprintf('cd %s && %s', escapeshellarg($applicationReleasePath), 'curl -s https://custom.domain.org/installer | php'));

--- a/tests/Unit/Task/Composer/InstallTaskTest.php
+++ b/tests/Unit/Task/Composer/InstallTaskTest.php
@@ -21,7 +21,7 @@ class InstallTaskTest extends BaseTaskTest
     {
         parent::setUp();
 
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): InstallTask

--- a/tests/Unit/Task/CreateArchiveTaskTest.php
+++ b/tests/Unit/Task/CreateArchiveTaskTest.php
@@ -120,7 +120,7 @@ class CreateArchiveTaskTest extends BaseTaskTest
         $this->filesystem->isDirectory(self::SOURCE_DIRECTORY)->willReturn(true);
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $sourcePath = $this->deployment->getApplicationReleasePath($this->application);
+        $sourcePath = $this->deployment->getApplicationReleasePath($this->node);
         $tarOptions = sprintf(' --transform="s,^%s,%s," ', ltrim($sourcePath, '/'), $options['baseDirectory']);
         $tarOptions .= sprintf(' -czf %s %s', $options['targetFile'], $sourcePath);
 
@@ -150,7 +150,7 @@ class CreateArchiveTaskTest extends BaseTaskTest
         $this->idGenerator->generate('f3_deploy')->willReturn('12345');
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $sourcePath = $this->deployment->getApplicationReleasePath($this->application);
+        $sourcePath = $this->deployment->getApplicationReleasePath($this->node);
         $tarOptions = sprintf(' --transform="s,^%s,%s," ', ltrim($sourcePath, '/'), $options['baseDirectory']);
         foreach ($options['exclude'] as $excludePattern) {
             $tarOptions .= sprintf(' --exclude="%s" ', $excludePattern);
@@ -187,7 +187,7 @@ class CreateArchiveTaskTest extends BaseTaskTest
         $this->filesystem->isDirectory(self::SOURCE_DIRECTORY)->willReturn(true);
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $sourcePath = $this->deployment->getApplicationReleasePath($this->application);
+        $sourcePath = $this->deployment->getApplicationReleasePath($this->node);
         $tarOptions = sprintf(' --transform="s,^%s,%s," ', ltrim($sourcePath, '/'), $options['baseDirectory']);
         $tarOptions .= sprintf(' -cjf %s %s', $options['targetFile'], $sourcePath);
 

--- a/tests/Unit/Task/CreateDirectoriesTaskTest.php
+++ b/tests/Unit/Task/CreateDirectoriesTaskTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace TYPO3\Surf\Tests\Unit\Task;
 
+use TYPO3\Surf\Exception\InvalidConfigurationException;
 use TYPO3\Surf\Task\CreateDirectoriesTask;
 
 class CreateDirectoriesTaskTest extends BaseTaskTest
@@ -22,14 +23,15 @@ class CreateDirectoriesTaskTest extends BaseTaskTest
 
     /**
      * @test
+     * @throws InvalidConfigurationException
      */
     public function executeSuccessfully(): void
     {
         $this->task->execute($this->node, $this->application, $this->deployment);
-        $this->assertCommandExecuted(sprintf('mkdir -p %s', $this->application->getReleasesPath()));
-        $this->assertCommandExecuted(sprintf('mkdir -p %s', $this->application->getSharedPath()));
-        $this->assertCommandExecuted(sprintf('mkdir -p %s', $this->deployment->getApplicationReleasePath($this->application)));
-        $this->assertCommandExecuted(sprintf('cd %s;ln -snf ./%s next', $this->application->getReleasesPath(), $this->deployment->getReleaseIdentifier()));
+        $this->assertCommandExecuted(sprintf('mkdir -p %s', $this->node->getReleasesPath()));
+        $this->assertCommandExecuted(sprintf('mkdir -p %s', $this->node->getSharedPath()));
+        $this->assertCommandExecuted(sprintf('mkdir -p %s', $this->deployment->getApplicationReleasePath($this->node)));
+        $this->assertCommandExecuted(sprintf('cd %s;ln -snf ./%s next', $this->node->getReleasesPath(), $this->deployment->getReleaseIdentifier()));
     }
 
     /**
@@ -38,7 +40,7 @@ class CreateDirectoriesTaskTest extends BaseTaskTest
     public function rollbackSuccessfully(): void
     {
         $this->task->rollback($this->node, $this->application, $this->deployment);
-        $this->assertCommandExecuted(sprintf('rm %s/next', $this->application->getReleasesPath()));
-        $this->assertCommandExecuted(sprintf('rm -rf %s', $this->deployment->getApplicationReleasePath($this->application)));
+        $this->assertCommandExecuted(sprintf('rm %s/next', $this->node->getReleasesPath()));
+        $this->assertCommandExecuted(sprintf('rm -rf %s', $this->deployment->getApplicationReleasePath($this->node)));
     }
 }

--- a/tests/Unit/Task/DumpDatabaseTaskTest.php
+++ b/tests/Unit/Task/DumpDatabaseTaskTest.php
@@ -20,7 +20,7 @@ class DumpDatabaseTaskTest extends BaseTaskTest
     {
         parent::setUp();
 
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): DumpDatabaseTask

--- a/tests/Unit/Task/Generic/CreateDirectoriesTaskTest.php
+++ b/tests/Unit/Task/Generic/CreateDirectoriesTaskTest.php
@@ -21,7 +21,8 @@ class CreateDirectoriesTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new CMS('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): CreateDirectoriesTask
@@ -37,7 +38,7 @@ class CreateDirectoriesTaskTest extends BaseTaskTest
         $options = ['directories' => ['media']];
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $this->assertCommandExecuted("cd {$this->deployment->getApplicationReleasePath($this->application)}");
+        $this->assertCommandExecuted("cd {$this->deployment->getApplicationReleasePath($this->node)}");
         $this->assertCommandExecuted('mkdir -p media');
     }
 

--- a/tests/Unit/Task/Generic/CreateSymlinksTaskTest.php
+++ b/tests/Unit/Task/Generic/CreateSymlinksTaskTest.php
@@ -21,7 +21,8 @@ class CreateSymlinksTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new CMS('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): CreateSymlinksTask
@@ -40,7 +41,7 @@ class CreateSymlinksTaskTest extends BaseTaskTest
         $options = ['symlinks' => ['media' => '../media']];
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $this->assertCommandExecuted("cd {$this->deployment->getApplicationReleasePath($this->application)}");
+        $this->assertCommandExecuted("cd {$this->deployment->getApplicationReleasePath($this->node)}");
         $this->assertCommandExecuted('ln -s ../media media');
     }
 
@@ -78,7 +79,7 @@ class CreateSymlinksTaskTest extends BaseTaskTest
         ];
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $this->assertCommandExecuted("cd {$this->deployment->getApplicationReleasePath($this->application)}");
+        $this->assertCommandExecuted("cd {$this->deployment->getApplicationReleasePath($this->node)}");
         $this->assertCommandExecuted('ln -s ../media media');
         $this->assertCommandExecuted('ln -s ../log log');
         $this->assertCommandExecuted('ln -s ../var var');

--- a/tests/Unit/Task/Generic/RollbackTaskTest.php
+++ b/tests/Unit/Task/Generic/RollbackTaskTest.php
@@ -26,7 +26,7 @@ final class RollbackTaskTest extends BaseTaskTest
      */
     public function executeSuccessfully(): void
     {
-        $releasesPath = $this->application->getReleasesPath();
+        $releasesPath = $this->node->getReleasesPath();
         $previousReleasePath = $releasesPath . '/previous';
         $currentReleasePath = $releasesPath . '/current';
 
@@ -53,7 +53,7 @@ previous',
      */
     public function canNotRollbackTooFewReleasesExist(): void
     {
-        $releasesPath = $this->application->getReleasesPath();
+        $releasesPath = $this->node->getReleasesPath();
 
         $this->responses = [
             sprintf('if [ -d %1$s/. ]; then find %1$s/. -maxdepth 1 -type d -exec basename {} \; ; fi', $releasesPath) => '.

--- a/tests/Unit/Task/Git/PushTaskTest.php
+++ b/tests/Unit/Task/Git/PushTaskTest.php
@@ -54,7 +54,7 @@ class PushTaskTest extends BaseTaskTest
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
         $this->assertCommandExecuted(
             sprintf(
-                'cd ' . $this->deployment->getApplicationReleasePath($this->application) . '; git push -f %s %s',
+                'cd ' . $this->deployment->getApplicationReleasePath($this->node) . '; git push -f %s %s',
                 $options['remote'],
                 $options['refspec']
             )
@@ -72,7 +72,7 @@ class PushTaskTest extends BaseTaskTest
             'recurseIntoSubmodules' => true
         ];
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
-        $targetPath = $this->deployment->getApplicationReleasePath($this->application);
+        $targetPath = $this->deployment->getApplicationReleasePath($this->node);
         $this->assertCommandExecuted(
             sprintf('cd ' . $targetPath . '; git push -f %s %s', $options['remote'], $options['refspec'])
         );

--- a/tests/Unit/Task/Git/TagTaskTest.php
+++ b/tests/Unit/Task/Git/TagTaskTest.php
@@ -20,7 +20,7 @@ class TagTaskTest extends BaseTaskTest
     {
         parent::setUp();
 
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): TagTask

--- a/tests/Unit/Task/GitCheckoutTaskTest.php
+++ b/tests/Unit/Task/GitCheckoutTaskTest.php
@@ -21,7 +21,7 @@ class GitCheckoutTaskTest extends BaseTaskTest
     {
         parent::setUp();
 
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): GitCheckoutTask

--- a/tests/Unit/Task/Laravel/ClearAuthResetsTaskTest.php
+++ b/tests/Unit/Task/Laravel/ClearAuthResetsTaskTest.php
@@ -28,7 +28,7 @@ class ClearAuthResetsTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**

--- a/tests/Unit/Task/Laravel/ConfigCacheTaskTest.php
+++ b/tests/Unit/Task/Laravel/ConfigCacheTaskTest.php
@@ -28,7 +28,7 @@ class ConfigCacheTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**

--- a/tests/Unit/Task/Laravel/CreateDirectoriesTaskTest.php
+++ b/tests/Unit/Task/Laravel/CreateDirectoriesTaskTest.php
@@ -26,7 +26,7 @@ class CreateDirectoriesTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**
@@ -35,7 +35,7 @@ class CreateDirectoriesTaskTest extends BaseTaskTest
     public function executeWithoutArgumentsExecutesViewCacheWithoutArguments(): void
     {
         $this->task->execute($this->node, $this->application, $this->deployment);
-        $this->assertCommandExecuted("cd {$this->application->getDeploymentPath()}");
+        $this->assertCommandExecuted("cd {$this->node->getDeploymentPath()}");
         $this->assertCommandExecuted('mkdir -p shared/storage/framework/cache/data');
         $this->assertCommandExecuted('mkdir -p shared/storage/framework/sessions');
         $this->assertCommandExecuted('mkdir -p shared/storage/framework/testing');

--- a/tests/Unit/Task/Laravel/DisableMaintenanceModeTaskTest.php
+++ b/tests/Unit/Task/Laravel/DisableMaintenanceModeTaskTest.php
@@ -28,7 +28,7 @@ class DisableMaintenanceModeTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**

--- a/tests/Unit/Task/Laravel/EnableMaintenanceModeTaskTest.php
+++ b/tests/Unit/Task/Laravel/EnableMaintenanceModeTaskTest.php
@@ -28,7 +28,7 @@ class EnableMaintenanceModeTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**

--- a/tests/Unit/Task/Laravel/EnvAwareTaskTest.php
+++ b/tests/Unit/Task/Laravel/EnvAwareTaskTest.php
@@ -26,7 +26,7 @@ class EnvAwareTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**
@@ -35,7 +35,7 @@ class EnvAwareTaskTest extends BaseTaskTest
     public function executeWithoutArgumentsExecutesViewCacheWithoutArguments(): void
     {
         $this->task->execute($this->node, $this->application, $this->deployment);
-        $this->assertCommandExecuted("test -f {$this->application->getSharedPath()}/.env");
-        $this->assertCommandExecuted("cp '{$this->application->getSharedPath()}/.env' '{$this->application->getReleasesPath()}/{$this->deployment->getReleaseIdentifier()}/.env'");
+        $this->assertCommandExecuted("test -f {$this->node->getSharedPath()}/.env");
+        $this->assertCommandExecuted("cp '{$this->node->getSharedPath()}/.env' '{$this->node->getReleasesPath()}/{$this->deployment->getReleaseIdentifier()}/.env'");
     }
 }

--- a/tests/Unit/Task/Laravel/MigrateFreshAndSeedTaskTest.php
+++ b/tests/Unit/Task/Laravel/MigrateFreshAndSeedTaskTest.php
@@ -28,7 +28,7 @@ class MigrateFreshAndSeedTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**

--- a/tests/Unit/Task/Laravel/MigrateFreshTaskTest.php
+++ b/tests/Unit/Task/Laravel/MigrateFreshTaskTest.php
@@ -28,7 +28,7 @@ class MigrateFreshTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**

--- a/tests/Unit/Task/Laravel/MigrateTaskTest.php
+++ b/tests/Unit/Task/Laravel/MigrateTaskTest.php
@@ -28,7 +28,7 @@ class MigrateTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**
@@ -59,7 +59,7 @@ class MigrateTaskTest extends BaseTaskTest
         $this->assertCommandExecuted(
             sprintf(
                 "cd '%s/%s'",
-                $this->application->getReleasesPath(),
+                $this->node->getReleasesPath(),
                 $this->deployment->getReleaseIdentifier()
             )
         );

--- a/tests/Unit/Task/Laravel/QueueRestartTaskTest.php
+++ b/tests/Unit/Task/Laravel/QueueRestartTaskTest.php
@@ -28,7 +28,7 @@ class QueueRestartTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**

--- a/tests/Unit/Task/Laravel/RouteCacheTaskTest.php
+++ b/tests/Unit/Task/Laravel/RouteCacheTaskTest.php
@@ -28,7 +28,7 @@ class RouteCacheTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**

--- a/tests/Unit/Task/Laravel/StorageLinkTaskTest.php
+++ b/tests/Unit/Task/Laravel/StorageLinkTaskTest.php
@@ -28,7 +28,7 @@ class StorageLinkTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**

--- a/tests/Unit/Task/Laravel/SymlinkStorageTaskTest.php
+++ b/tests/Unit/Task/Laravel/SymlinkStorageTaskTest.php
@@ -26,7 +26,7 @@ class SymlinkStorageTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**
@@ -35,8 +35,8 @@ class SymlinkStorageTaskTest extends BaseTaskTest
     public function executeWithoutArgumentsExecutesViewCacheWithoutArguments(): void
     {
         $this->task->execute($this->node, $this->application, $this->deployment);
-        $this->assertCommandExecuted("cd '{$this->application->getReleasesPath()}/{$this->deployment->getReleaseIdentifier()}'");
+        $this->assertCommandExecuted("cd '{$this->node->getReleasesPath()}/{$this->deployment->getReleaseIdentifier()}'");
         $this->assertCommandExecuted("{ [ -d '../../shared/storage' ] || mkdir -p '../../shared/storage' ; }");
-        $this->assertCommandExecuted("ln -sf '../../shared/storage' '{$this->application->getReleasesPath()}/{$this->deployment->getReleaseIdentifier()}/storage'");
+        $this->assertCommandExecuted("ln -sf '../../shared/storage' '{$this->node->getReleasesPath()}/{$this->deployment->getReleaseIdentifier()}/storage'");
     }
 }

--- a/tests/Unit/Task/Laravel/ViewCacheTaskTest.php
+++ b/tests/Unit/Task/Laravel/ViewCacheTaskTest.php
@@ -28,7 +28,7 @@ class ViewCacheTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Laravel('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     /**

--- a/tests/Unit/Task/LockDeploymentTaskTest.php
+++ b/tests/Unit/Task/LockDeploymentTaskTest.php
@@ -20,7 +20,7 @@ final class LockDeploymentTaskTest extends BaseTaskTest
     protected function setUp(): void
     {
         parent::setUp();
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): LockDeploymentTask
@@ -41,7 +41,7 @@ final class LockDeploymentTaskTest extends BaseTaskTest
     {
         $testIfDeploymentLockFileExists = sprintf(
             'if [ -f %s ]; then echo 1; else echo 0; fi',
-            escapeshellarg($this->application->getDeploymentPath() . '/.surf/deploy.lock')
+            escapeshellarg($this->node->getDeploymentPath() . '/.surf/deploy.lock')
         );
         $this->responses = [
             $testIfDeploymentLockFileExists => false,
@@ -57,7 +57,7 @@ final class LockDeploymentTaskTest extends BaseTaskTest
     {
         $testIfDeploymentLockFileExists = sprintf(
             'if [ -f %s ]; then echo 1; else echo 0; fi',
-            escapeshellarg($this->application->getDeploymentPath() . '/.surf/deploy.lock')
+            escapeshellarg($this->node->getDeploymentPath() . '/.surf/deploy.lock')
         );
         $this->responses = [
             $testIfDeploymentLockFileExists => true,

--- a/tests/Unit/Task/Neos/Flow/CopyConfigurationTaskTest.php
+++ b/tests/Unit/Task/Neos/Flow/CopyConfigurationTaskTest.php
@@ -25,7 +25,8 @@ class CopyConfigurationTaskTest extends BaseTaskTest
         parent::setUp();
 
         $this->application = new Flow('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): CopyConfigurationTask
@@ -46,7 +47,7 @@ class CopyConfigurationTaskTest extends BaseTaskTest
         $this->task->execute($this->node, $this->application, $this->deployment, []);
 
         $configPath = $this->deployment->getDeploymentConfigurationPath();
-        $releasesPath = $this->deployment->getApplicationReleasePath($this->application);
+        $releasesPath = $this->deployment->getApplicationReleasePath($this->node);
 
         $this->assertCommandExecuted("mkdir -p '{$releasesPath}/Configuration/'");
         $this->assertCommandExecuted("cp '{$configPath}/Settings.yaml' '{$releasesPath}/Configuration/'");
@@ -70,7 +71,7 @@ class CopyConfigurationTaskTest extends BaseTaskTest
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
         $configPath = $this->deployment->getDeploymentConfigurationPath();
-        $releasesPath = $this->deployment->getApplicationReleasePath($this->application);
+        $releasesPath = $this->deployment->getApplicationReleasePath($this->node);
 
         $this->assertCommandExecuted("mkdir -p '{$releasesPath}/Configuration/Production/'");
         $this->assertCommandExecuted("cp '{$configPath}/Production/Settings.php' '{$releasesPath}/Configuration/Production/'");
@@ -89,7 +90,7 @@ class CopyConfigurationTaskTest extends BaseTaskTest
         $this->task->execute($this->node, $this->application, $this->deployment, []);
 
         $configPath = $this->deployment->getDeploymentConfigurationPath();
-        $releasesPath = $this->deployment->getApplicationReleasePath($this->application);
+        $releasesPath = $this->deployment->getApplicationReleasePath($this->node);
 
         $this->assertCommandExecuted("ssh remote \"mkdir -p '{$releasesPath}/Configuration/'\"");
         $this->assertCommandExecuted("scp '{$configPath}/Settings.yaml' remote:\"'{$releasesPath}/Configuration/'\"");
@@ -111,7 +112,7 @@ class CopyConfigurationTaskTest extends BaseTaskTest
         $this->task->execute($this->node, $this->application, $this->deployment, []);
 
         $configPath = $this->deployment->getDeploymentConfigurationPath();
-        $releasesPath = $this->deployment->getApplicationReleasePath($this->application);
+        $releasesPath = $this->deployment->getApplicationReleasePath($this->node);
 
         $this->assertCommandExecuted("ssh -o PubkeyAuthentication=no remote \"mkdir -p '{$releasesPath}/Configuration/'\"");
         $this->assertCommandExecuted("scp -o PubkeyAuthentication=no '{$configPath}/Settings.yaml' remote:\"'{$releasesPath}/Configuration/'\"");

--- a/tests/Unit/Task/Neos/Flow/CreateDirectoriesTaskTest.php
+++ b/tests/Unit/Task/Neos/Flow/CreateDirectoriesTaskTest.php
@@ -24,7 +24,8 @@ class CreateDirectoriesTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new CMS('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): CreateDirectoriesTask
@@ -40,7 +41,7 @@ class CreateDirectoriesTaskTest extends BaseTaskTest
         $options = [];
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $this->assertCommandExecuted("cd {$this->application->getDeploymentPath()}");
+        $this->assertCommandExecuted("cd {$this->node->getDeploymentPath()}");
         $this->assertCommandExecuted('mkdir -p shared/Data/Logs');
         $this->assertCommandExecuted('mkdir -p shared/Data/Persistent');
         $this->assertCommandExecuted('mkdir -p shared/Configuration');

--- a/tests/Unit/Task/Neos/Flow/SymlinkConfigurationTaskTest.php
+++ b/tests/Unit/Task/Neos/Flow/SymlinkConfigurationTaskTest.php
@@ -28,7 +28,8 @@ class SymlinkConfigurationTaskTest extends BaseTaskTest
         parent::setUp();
 
         $this->application = new Flow('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): SymlinkConfigurationTask

--- a/tests/Unit/Task/SymlinkReleaseTaskTest.php
+++ b/tests/Unit/Task/SymlinkReleaseTaskTest.php
@@ -45,13 +45,13 @@ class SymlinkReleaseTaskTest extends BaseTaskTest
     {
         $this->task->rollback($this->node, $this->application, $this->deployment);
         $this->assertCommandExecuted(
-            'cd ' . $this->application->getReleasesPath() . ' && rm -f ./current && mv ./previous ./current'
+            'cd ' . $this->node->getReleasesPath() . ' && rm -f ./current && mv ./previous ./current'
         );
     }
 
     private function expectedCommand(): string
     {
-        return 'cd ' . $this->application->getReleasesPath()
+        return 'cd ' . $this->node->getReleasesPath()
             . ' && rm -rf ./previous && if [ -e ./current ]; then mv ./current ./previous; fi && ln -s ./'
             . $this->deployment->getReleaseIdentifier() . ' ./current && rm -rf ./next';
     }

--- a/tests/Unit/Task/TYPO3/CMS/CompareDatabaseTaskTest.php
+++ b/tests/Unit/Task/TYPO3/CMS/CompareDatabaseTaskTest.php
@@ -25,7 +25,7 @@ class CompareDatabaseTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new CMS('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): CompareDatabaseTask

--- a/tests/Unit/Task/TYPO3/CMS/FlushCachesTaskTest.php
+++ b/tests/Unit/Task/TYPO3/CMS/FlushCachesTaskTest.php
@@ -25,7 +25,8 @@ class FlushCachesTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new CMS('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): FlushCachesTask

--- a/tests/Unit/Task/TYPO3/CMS/SetUpExtensionsTaskTest.php
+++ b/tests/Unit/Task/TYPO3/CMS/SetUpExtensionsTaskTest.php
@@ -21,7 +21,8 @@ class SetUpExtensionsTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new CMS('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+
+        $this->node->setDeploymentPath('/home/jdoe/app');
         $this->expectTypo3ConsoleVersion('TYPO3 Console 5.8.6');
     }
 
@@ -68,7 +69,7 @@ class SetUpExtensionsTaskTest extends BaseTaskTest
             'extensionKeys' => ['foo', 'bar']
         ];
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
-        $this->assertCommandExecuted("cd '{$this->deployment->getApplicationReleasePath($this->application)}'");
+        $this->assertCommandExecuted("cd '{$this->deployment->getApplicationReleasePath($this->node)}'");
         $this->assertCommandExecuted("php 'vendor/bin/typo3cms' 'extension:setup' 'foo,bar'");
     }
 
@@ -83,9 +84,9 @@ class SetUpExtensionsTaskTest extends BaseTaskTest
             'webDirectory' => '/web/',
         ];
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
-        $this->assertCommandExecuted("cd '{$this->deployment->getApplicationReleasePath($this->application)}'");
+        $this->assertCommandExecuted("cd '{$this->deployment->getApplicationReleasePath($this->node)}'");
         $this->assertCommandExecuted(
-            "test -f '{$this->deployment->getApplicationReleasePath($this->application)}/vendor/bin/typo3cms'"
+            "test -f '{$this->deployment->getApplicationReleasePath($this->node)}/vendor/bin/typo3cms'"
         );
         $this->assertCommandExecuted("php 'vendor/bin/typo3cms' 'extension:setup' 'foo,bar'");
     }
@@ -102,7 +103,7 @@ class SetUpExtensionsTaskTest extends BaseTaskTest
             'extensionKeys' => ['foo', 'bar']
         ];
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
-        $this->assertCommandExecuted("cd '{$this->deployment->getApplicationReleasePath($this->application)}'");
+        $this->assertCommandExecuted("cd '{$this->deployment->getApplicationReleasePath($this->node)}'");
         $this->assertCommandExecuted("php 'vendor/bin/typo3cms' 'extension:setup' '-e' 'foo' '-e' 'bar'");
     }
 
@@ -118,7 +119,7 @@ class SetUpExtensionsTaskTest extends BaseTaskTest
             'extensionKeys' => ['foo', 'bar']
         ];
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
-        $this->assertCommandExecuted("cd '{$this->deployment->getApplicationReleasePath($this->application)}'");
+        $this->assertCommandExecuted("cd '{$this->deployment->getApplicationReleasePath($this->node)}'");
         $this->assertCommandExecuted("php 'vendor/bin/typo3cms' 'extension:setup' '-e' 'foo' '-e' 'bar'");
     }
 

--- a/tests/Unit/Task/TYPO3/CMS/SymlinkDataTaskTest.php
+++ b/tests/Unit/Task/TYPO3/CMS/SymlinkDataTaskTest.php
@@ -21,7 +21,8 @@ class SymlinkDataTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new CMS('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): SymlinkDataTask
@@ -41,7 +42,7 @@ class SymlinkDataTaskTest extends BaseTaskTest
         $options = $this->mergeOptions($options);
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $releasePath = $this->deployment->getApplicationReleasePath($this->application);
+        $releasePath = $this->deployment->getApplicationReleasePath($this->node);
         $dataPath = '../../shared/Data';
         $this->assertCommandExecuted("cd '{$releasePath}'");
         $this->assertCommandExecuted("mkdir -p '{$dataPath}/fileadmin'");
@@ -62,7 +63,7 @@ class SymlinkDataTaskTest extends BaseTaskTest
         $options = $this->mergeOptions($options);
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $releasePath = $this->deployment->getApplicationReleasePath($this->application);
+        $releasePath = $this->deployment->getApplicationReleasePath($this->node);
         $dataPath = '../../shared/Data';
         self::assertNotContains("mkdir -p '{$dataPath}/uploads'", $this->commands['executed']);
         self::assertNotContains("ln -sf '{$dataPath}/uploads' '{$releasePath}/uploads'", $this->commands['executed']);
@@ -84,7 +85,7 @@ class SymlinkDataTaskTest extends BaseTaskTest
         $options = $this->mergeOptions($options);
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $releasePath = $this->deployment->getApplicationReleasePath($this->application);
+        $releasePath = $this->deployment->getApplicationReleasePath($this->node);
         $dataPath = '../../shared/Data';
         $this->assertCommandExecuted("cd '{$releasePath}'");
         $this->assertCommandExecuted("mkdir -p '{$dataPath}/fileadmin'");
@@ -108,7 +109,7 @@ class SymlinkDataTaskTest extends BaseTaskTest
         $options = $this->mergeOptions($options);
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $releasePath = $this->deployment->getApplicationReleasePath($this->application);
+        $releasePath = $this->deployment->getApplicationReleasePath($this->node);
         $dataPath = '../../shared/Data';
         $this->assertCommandExecuted("cd '{$releasePath}'");
         $this->assertCommandExecuted("mkdir -p '{$dataPath}/fileadmin'");
@@ -129,7 +130,7 @@ class SymlinkDataTaskTest extends BaseTaskTest
         $options = $this->mergeOptions($options);
         $this->task->execute($this->node, $this->application, $this->deployment, $options);
 
-        $releasePath = $this->deployment->getApplicationReleasePath($this->application);
+        $releasePath = $this->deployment->getApplicationReleasePath($this->node);
         $dataPath = '../../shared/Data';
         $this->assertCommandExecuted("cd '{$releasePath}'");
         $this->assertCommandExecuted("mkdir -p '{$dataPath}/fileadmin'");

--- a/tests/Unit/Task/Transfer/RsyncTaskTest.php
+++ b/tests/Unit/Task/Transfer/RsyncTaskTest.php
@@ -24,7 +24,8 @@ class RsyncTaskTest extends BaseTaskTest
         parent::setUp();
 
         $this->application = new Flow('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): RsyncTask

--- a/tests/Unit/Task/Transfer/ScpTaskTest.php
+++ b/tests/Unit/Task/Transfer/ScpTaskTest.php
@@ -21,7 +21,8 @@ class ScpTaskTest extends BaseTaskTest
     {
         parent::setUp();
         $this->application = new Flow('TestApplication');
-        $this->application->setDeploymentPath('/home/jdoe/app');
+
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): ScpTask

--- a/tests/Unit/Task/UnlockDeploymentTaskTest.php
+++ b/tests/Unit/Task/UnlockDeploymentTaskTest.php
@@ -18,7 +18,7 @@ final class UnlockDeploymentTaskTest extends BaseTaskTest
     protected function setUp(): void
     {
         parent::setUp();
-        $this->application->setDeploymentPath('/home/jdoe/app');
+        $this->node->setDeploymentPath('/home/jdoe/app');
     }
 
     protected function createTask(): UnlockDeploymentTask
@@ -33,7 +33,7 @@ final class UnlockDeploymentTaskTest extends BaseTaskTest
     {
         $this->task->execute($this->node, $this->application, $this->deployment);
         $this->assertCommandExecuted(
-            sprintf('rm %s', escapeshellarg($this->application->getDeploymentPath() . '/.surf/deploy.lock'))
+            sprintf('rm %s', escapeshellarg($this->node->getDeploymentPath() . '/.surf/deploy.lock'))
         );
     }
 
@@ -45,7 +45,7 @@ final class UnlockDeploymentTaskTest extends BaseTaskTest
         $this->deployment->setForceRun(true);
         $this->task->execute($this->node, $this->application, $this->deployment);
         $this->assertCommandExecuted(
-            sprintf('rm -f %s', escapeshellarg($this->application->getDeploymentPath() . '/.surf/deploy.lock'))
+            sprintf('rm -f %s', escapeshellarg($this->node->getDeploymentPath() . '/.surf/deploy.lock'))
         );
     }
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)

My local deployment tests have also run successfully.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Breaking refactoring

* **What is the current behavior?** (You can also link to an open issue here)

It is not possible to define the deployment path per node (useful for the case when you have one application but want to deploy it to the same node but different directories where each app is running independently)

* **What is the new behavior (if this is a feature change)?**

The deployment path can be defined for each node individually

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

yes. Instead of setting the deployment path in the application, do the same on the node.

* **Additional info**

As a next step some tasks like the `GitTask` should only be run once as it doesn't make sense to run them twice for the same application. Same is true for:
- LocalInstallTask
- any build tasks which are executed locally (on the local node)