### PR TITLE
BUGFIX: Also check for deploy-config in home-dir

### DIFF
--- a/src/Integration/Factory.php
+++ b/src/Integration/Factory.php
@@ -146,16 +146,18 @@ class Factory implements FactoryInterface, ContainerAwareInterface
         }
 
         $deploymentPathAndFilename = Files::concatenatePaths([$deploymentConfigurationPath, $deploymentName . '.php']);
+
         if (! $this->filesystem->fileExists($deploymentPathAndFilename)) {
-           
             //Check if file exists in home-dir configurations instead
             $deploymentPathAndFilename = $deploymentPathAndFilename = Files::concatenatePaths([$this->getHomeDirectory(), 'deployments', $deploymentName . '.php']);
-            if (! $this->filesystem->fileExists($deploymentPathAndFilename)) {
-                $this->logger->error(sprintf("The deployment file %s does not exist.\n", $deploymentPathAndFilename));
-                $deployment = new FailedDeployment();
-                $deployment->setLogger($this->logger);
-                return $deployment;
-            }
+        }
+
+        if (! $this->filesystem->fileExists($deploymentPathAndFilename)) {
+            $this->logger->error(sprintf("The deployment file %s does not exist.\n", $deploymentPathAndFilename));
+            $deployment = new FailedDeployment();
+            $deployment->setLogger($this->logger);
+
+            return $deployment;
         }
 
         $deployment = new Deployment($deploymentName);

--- a/src/Integration/Factory.php
+++ b/src/Integration/Factory.php
@@ -147,11 +147,15 @@ class Factory implements FactoryInterface, ContainerAwareInterface
 
         $deploymentPathAndFilename = Files::concatenatePaths([$deploymentConfigurationPath, $deploymentName . '.php']);
         if (! $this->filesystem->fileExists($deploymentPathAndFilename)) {
-            $this->logger->error(sprintf("The deployment file %s does not exist.\n", $deploymentPathAndFilename));
-            $deployment = new FailedDeployment();
-            $deployment->setLogger($this->logger);
-
-            return $deployment;
+           
+            //Check if file exists in home-dir configurations instead
+            $deploymentPathAndFilename = $deploymentPathAndFilename = Files::concatenatePaths([$this->getHomeDirectory(), 'deployments', $deploymentName . '.php']);
+            if (! $this->filesystem->fileExists($deploymentPathAndFilename)) {
+                $this->logger->error(sprintf("The deployment file %s does not exist.\n", $deploymentPathAndFilename));
+                $deployment = new FailedDeployment();
+                $deployment->setLogger($this->logger);
+                return $deployment;
+            }
         }
 
         $deployment = new Deployment($deploymentName);

--- a/tests/Unit/Integration/FactoryTest.php
+++ b/tests/Unit/Integration/FactoryTest.php
@@ -340,7 +340,11 @@ class FactoryTest extends TestCase
         $this->filesystem->fileExists(getenv('HOME') . '/.surf/workspace')->willReturn(true);
         $this->filesystem->fileExists('foo/foo.php')->willReturn(false);
 
-        $this->logger->error("The deployment file foo/foo.php does not exist.\n")->shouldBeCalledOnce();
+        $deploymentFile = getenv('HOME') . '/.surf/deployments/foo.php';
+
+        $this->filesystem->fileExists($deploymentFile)->willReturn(false);
+
+        $this->logger->error(sprintf("The deployment file %s does not exist.\n", $deploymentFile))->shouldBeCalledOnce();
 
         $deployment = $this->subject->getDeployment('foo');
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix (see description below)


* **What is the current behavior?**
If you have a `.surf`-Folder in your project, surf only checks for config-files within that folder.  
That causes trouble, if you want to use your default-deployment from your home directory in one case, but have a local `.surf`-Folder for other cases. Adding `--configurationPath` is annoying at this point.


* **What is the new behavior?**
If the configuration-file with the give deployment name wasn't found locally, it checks for the same file in the home-dir before failing.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
I don't think so.