### PR TITLE
[TASK] Replace error-prone shortcut to documentation in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Some of the features of the Surf package:
 
 ## Documentation
 
-For further information please read the documentation https://docs.typo3.org/surf/
+For further information please read the documentation https://docs.typo3.org/other/typo3/surf/master/en-us/.
 
 ### Contributing to the documentation
 


### PR DESCRIPTION
The shortcut `https://docs.typo3.org/surf` is configured manually and thus error-prone as it can link to outdated documentation. Using `https://docs.typo3.org/other/typo3/surf/master/en-us/` always links to the latest version of the documentation.

See https://github.com/TYPO3-Documentation/T3DocTeam/issues/159 for further details.