### PR TITLE
[FEATURE] Allow wildcards in tags

### DIFF
--- a/src/Task/Git/AbstractCheckoutTask.php
+++ b/src/Task/Git/AbstractCheckoutTask.php
@@ -36,7 +36,14 @@ abstract class AbstractCheckoutTask extends Task implements ShellCommandServiceA
                 throw new TaskExecutionException('The given sha1  "' . $options['sha1'] . '" is invalid', 1335974900);
             }
         } elseif (isset($options['tag'])) {
-            $sha1 = $this->shell->execute("git ls-remote {$options['repositoryUrl']} refs/tags/{$options['tag']} | awk '{print $1 }'", $node, $deployment, true);
+            $sha1 = $this->shell->execute(
+                "git ls-remote --sort=version:refname {$options['repositoryUrl']} 'refs/tags/{$options['tag']}' "
+                    . "| awk '{print $1 }' "
+                    . "| tail --lines=1",
+                $node,
+                $deployment,
+                true
+            );
             if (preg_match('/[a-f0-9]{40}/', $sha1) === 0) {
                 throw new TaskExecutionException('Could not retrieve sha1 of git tag "' . $options['tag'] . '"', 1335974915);
             }

--- a/tests/Unit/Task/GitCheckoutTaskTest.php
+++ b/tests/Unit/Task/GitCheckoutTaskTest.php
@@ -52,6 +52,45 @@ class GitCheckoutTaskTest extends BaseTaskTest
         $this->assertCommandExecuted('git clean -q -d -x -ff');
     }
 
+
+    /**
+     * @test
+     */
+    public function executeWithTagOptionAndValidSha1FetchesResetsAndCopiesRepository(): void
+    {
+        $options = [
+            'repositoryUrl' => 'ssh://git.example.com/project/path.git',
+            'tag' => 'myTag'
+        ];
+        $this->responses = [
+            'git ls-remote --sort=version:refname ssh://git.example.com/project/path.git \'refs/tags/myTag\' | awk \'{print $1 }\' | tail --lines=1' => 'd5b7769852a5faa69574fcd3db0799f4ffbd9eec'
+        ];
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+
+        $this->assertCommandExecuted('git fetch -q origin');
+        $this->assertCommandExecuted('git reset -q --hard d5b7769852a5faa69574fcd3db0799f4ffbd9eec');
+        $this->assertCommandExecuted('cp -RPp /home/jdoe/app/cache/transfer/. /home/jdoe/app/releases/');
+    }
+
+    /**
+     * @test
+     */
+    public function executeWithTagWildcardOptionAndValidSha1FetchesResetsAndCopiesRepository(): void
+    {
+        $options = [
+            'repositoryUrl' => 'ssh://git.example.com/project/path.git',
+            'tag' => 'staging-*'
+        ];
+        $this->responses = [
+            'git ls-remote --sort=version:refname ssh://git.example.com/project/path.git \'refs/tags/staging-*\' | awk \'{print $1 }\' | tail --lines=1' => 'd5b7769852a5faa69574fcd3db0799f4ffbd9eec'
+        ];
+        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+
+        $this->assertCommandExecuted('git fetch -q origin');
+        $this->assertCommandExecuted('git reset -q --hard d5b7769852a5faa69574fcd3db0799f4ffbd9eec');
+        $this->assertCommandExecuted('cp -RPp /home/jdoe/app/cache/transfer/. /home/jdoe/app/releases/');
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
Fixes #444

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
See #444.
Currently, refspecs that return multiple commits are not possible.


* **What is the new behavior (if this is a feature change)?**
The old behaviour for "tag" is retained and does not change. 

Additionally, wildcards in tag-refs are allowed as per `git ls-remote` .
Multiple matching tags are sorted version*y* (e.g. 1.10.0 > 1.1.0) (with fallback to lexical sorting).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
