### PR TITLE
[BUGFIX] Fix version 2.3.2 for deployment of TYPO3 11.5 with TYPO3 Console 7.0 and option "extensionKeys"

### DIFF
--- a/src/Task/TYPO3/CMS/SetUpExtensionsTask.php
+++ b/src/Task/TYPO3/CMS/SetUpExtensionsTask.php
@@ -50,7 +50,10 @@ class SetUpExtensionsTask extends AbstractCliTask
             $commandArguments[] = 'extension:setupactive';
         } else {
             $commandArguments[] = 'extension:setup';
-            $commandArguments[] = implode(',', $options['extensionKeys']);
+            foreach ($options['extensionKeys'] as $extensionKey) {
+                $commandArguments[] = '-e';
+                $commandArguments[] = $extensionKey;
+            }
         }
 
         $this->executeCliCommand(


### PR DESCRIPTION
**Attention**: This fix is based on Surf version 2.3.2! (Version for `master`: #452)

Related: #450