### PR TITLE
[BUGFIX] Fix master for deployment of TYPO3 11.5 with TYPO3 Console 7.0 and option "extensionKeys"

### DIFF
--- a/src/Task/TYPO3/CMS/SetUpExtensionsTask.php
+++ b/src/Task/TYPO3/CMS/SetUpExtensionsTask.php
@@ -42,7 +42,10 @@ class SetUpExtensionsTask extends AbstractCliTask
             $commandArguments[] = 'extension:setupactive';
         } else {
             $commandArguments[] = 'extension:setup';
-            $commandArguments[] = implode(',', $options['extensionKeys']);
+            foreach ($options['extensionKeys'] as $extensionKey) {
+                $commandArguments[] = '-e';
+                $commandArguments[] = $extensionKey;
+            }
         }
 
         $this->executeCliCommand(

--- a/src/Task/TYPO3/CMS/SetUpExtensionsTask.php
+++ b/src/Task/TYPO3/CMS/SetUpExtensionsTask.php
@@ -30,6 +30,7 @@ class SetUpExtensionsTask extends AbstractCliTask
 
         try {
             $scriptFileName = $this->getConsoleScriptFileName($node, $application, $deployment, $options);
+            $consoleVersion = $this->getConsoleVersion($scriptFileName, $node, $application, $deployment, $options);
         } catch (InvalidConfigurationException $e) {
             $deployment->getLogger()->warning('TYPO3 Console script (' . $options['scriptFileName'] . ') was not found! Make sure it is available in your project, you set the "scriptFileName" option correctly or remove this task (' . __CLASS__ . ') in your deployment configuration!');
             return;
@@ -38,13 +39,27 @@ class SetUpExtensionsTask extends AbstractCliTask
         $options = $this->configureOptions($options);
 
         $commandArguments = [$scriptFileName];
-        if (empty($options['extensionKeys'])) {
-            $commandArguments[] = 'extension:setupactive';
-        } else {
+        
+        // TYPO3 Console behaviour changed since version 7:
+        // Version <7: `typo3cms extension:setupactive` was called to install all extensions
+        // And `typo3cms extension:setup extension_key_1,extension_key_2` was called to install some extensions by their key
+        // Version >=7: `typo3cms extension:setup` is called to install all extensions
+        // `typo3cms extension:setup -e extension_key_1 -e extension_key_2` is called to install these two extensions
+
+        if ((int)$consoleVersion >= 7) {
             $commandArguments[] = 'extension:setup';
-            foreach ($options['extensionKeys'] as $extensionKey) {
-                $commandArguments[] = '-e';
-                $commandArguments[] = $extensionKey;
+            if (!empty($options['extensionKeys'])) {
+                foreach ($options['extensionKeys'] as $extensionKey) {
+                    $commandArguments[] = '-e';
+                    $commandArguments[] = $extensionKey;
+                }
+            }
+        } else {
+            if (empty($options['extensionKeys'])) {
+                $commandArguments[] = 'extension:setupactive';
+            } else {
+                $commandArguments[] = 'extension:setup';
+                $commandArguments[] = implode(',', $options['extensionKeys']);
             }
         }
 
@@ -61,5 +76,33 @@ class SetUpExtensionsTask extends AbstractCliTask
     {
         $resolver->setDefault('extensionKeys', []);
         $resolver->setAllowedTypes('extensionKeys', 'array');
+    }
+
+    /**
+     * Get TYPO3 Console version string, e.g. "7.0.0"
+     *
+     * @param string $scriptFileName
+     * @param \TYPO3\Surf\Domain\Model\Node $node
+     * @param CMS|\TYPO3\Surf\Domain\Model\Application $application
+     * @param \TYPO3\Surf\Domain\Model\Deployment $deployment
+     * @param array $options
+     * @return string Returns empty string ("") if version could not be determined
+     */
+    protected function getConsoleVersion(
+        string $scriptFileName,
+        \TYPO3\Surf\Domain\Model\Node $node,
+        \TYPO3\Surf\Domain\Model\Application $application,
+        \TYPO3\Surf\Domain\Model\Deployment $deployment,
+        array $options
+    ): string {
+        $consoleVersionCommandOutput = $this->executeCliCommand(
+            [$scriptFileName, '--version'],
+            $node,
+            $application,
+            $deployment,
+            $options
+        );
+        $consoleVersionLine = explode(PHP_EOL, $consoleVersionCommandOutput)[0] ?? '';
+        return str_replace('TYPO3 Console ', '', $consoleVersionLine);
     }
 }

--- a/src/Task/TYPO3/CMS/SetUpExtensionsTask.php
+++ b/src/Task/TYPO3/CMS/SetUpExtensionsTask.php
@@ -17,14 +17,21 @@ use TYPO3\Surf\Exception\InvalidConfigurationException;
 use Webmozart\Assert\Assert;
 
 /**
- * This task sets up extensions using typo3_console.
+ * This task sets up extensions using the TYPO3 Console (typo3_console).
  * Set up means: database migration, files, database data.
  *
  * @param array $extensionKeys=array() Extension keys for extensions that should be set up. If empty, all active non core extensions will be set up.
  */
 class SetUpExtensionsTask extends AbstractCliTask
 {
-    public function execute(Node $node, Application $application, Deployment $deployment, array $options = [])
+    /**
+     * @param Node $node
+     * @param Application $application
+     * @param Deployment $deployment
+     * @param array $options
+     * @return void
+     */
+    public function execute(Node $node, Application $application, Deployment $deployment, array $options = []): void
     {
         Assert::isInstanceOf($application, CMS::class);
 
@@ -32,7 +39,10 @@ class SetUpExtensionsTask extends AbstractCliTask
             $scriptFileName = $this->getConsoleScriptFileName($node, $application, $deployment, $options);
             $consoleVersion = $this->getConsoleVersion($scriptFileName, $node, $application, $deployment, $options);
         } catch (InvalidConfigurationException $e) {
-            $deployment->getLogger()->warning('TYPO3 Console script (' . $options['scriptFileName'] . ') was not found! Make sure it is available in your project, you set the "scriptFileName" option correctly or remove this task (' . __CLASS__ . ') in your deployment configuration!');
+            $deployment->getLogger()->warning('TYPO3 Console script (' . $options['scriptFileName'] .
+                ') was not found! Make sure it is available in your project, you set the "scriptFileName" option correctly or remove this task (' .
+                __CLASS__ . ') in your deployment configuration!'
+            );
             return;
         }
 
@@ -72,7 +82,11 @@ class SetUpExtensionsTask extends AbstractCliTask
         );
     }
 
-    protected function resolveOptions(OptionsResolver $resolver)
+    /**
+     * @parameter OptionsResolver $resolver
+     * @return void
+     */
+    protected function resolveOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefault('extensionKeys', []);
         $resolver->setAllowedTypes('extensionKeys', 'array');
@@ -82,17 +96,17 @@ class SetUpExtensionsTask extends AbstractCliTask
      * Get TYPO3 Console version string, e.g. "7.0.0"
      *
      * @param string $scriptFileName
-     * @param \TYPO3\Surf\Domain\Model\Node $node
-     * @param CMS|\TYPO3\Surf\Domain\Model\Application $application
-     * @param \TYPO3\Surf\Domain\Model\Deployment $deployment
+     * @param Node $node
+     * @param Application $application
+     * @param Deployment $deployment
      * @param array $options
      * @return string Returns empty string ("") if version could not be determined
      */
     protected function getConsoleVersion(
         string $scriptFileName,
-        \TYPO3\Surf\Domain\Model\Node $node,
-        \TYPO3\Surf\Domain\Model\Application $application,
-        \TYPO3\Surf\Domain\Model\Deployment $deployment,
+        Node $node,
+        Application $application,
+        Deployment $deployment,
         array $options
     ): string {
         $consoleVersionCommandOutput = $this->executeCliCommand(

--- a/tests/Unit/Task/TYPO3/CMS/SetUpExtensionsTaskTest.php
+++ b/tests/Unit/Task/TYPO3/CMS/SetUpExtensionsTaskTest.php
@@ -42,12 +42,18 @@ class SetUpExtensionsTaskTest extends BaseTaskTest
      */
     public function executeWithoutOptionExecutesSetUpActive(): void
     {
-        $this->task->execute(
-            $this->node,
-            $this->application,
-            $this->deployment,
-            ['scriptFileName' => 'vendor/bin/typo3cms']
-        );
+        $mockTask = $this->getMockTaskForConsoleVersion('7.0.0');
+        $mockTask->execute($this->node, $this->application, $this->deployment, ['scriptFileName' => 'vendor/bin/typo3cms']);
+        $this->assertCommandExecuted("php 'vendor/bin/typo3cms' 'extension:setup'");
+    }
+
+    /**
+     * @test
+     */
+    public function executeWithoutOptionExecutesSetUpActiveForOldConsoleVersion(): void
+    {
+        $mockTask = $this->getMockTaskForConsoleVersion('6.9.9');
+        $mockTask->execute($this->node, $this->application, $this->deployment, ['scriptFileName' => 'vendor/bin/typo3cms']);
         $this->assertCommandExecuted("php 'vendor/bin/typo3cms' 'extension:setupactive'");
     }
 
@@ -60,7 +66,24 @@ class SetUpExtensionsTaskTest extends BaseTaskTest
             'scriptFileName' => 'vendor/bin/typo3cms',
             'extensionKeys' => ['foo', 'bar']
         ];
-        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+
+        $mockTask = $this->getMockTaskForConsoleVersion('7.0.0');
+        $mockTask->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted("php 'vendor/bin/typo3cms' 'extension:setup' '-e' 'foo' '-e' 'bar'");
+    }
+
+    /**
+     * @test
+     */
+    public function executeWithOptionExecutesSetUpWithOptionForOldConsoleVersion(): void
+    {
+        $options = [
+            'scriptFileName' => 'vendor/bin/typo3cms',
+            'extensionKeys' => ['foo', 'bar']
+        ];
+
+        $mockTask = $this->getMockTaskForConsoleVersion('6.9.9');
+        $mockTask->execute($this->node, $this->application, $this->deployment, $options);
         $this->assertCommandExecuted("php 'vendor/bin/typo3cms' 'extension:setup' 'foo,bar'");
     }
 
@@ -73,7 +96,25 @@ class SetUpExtensionsTaskTest extends BaseTaskTest
             'scriptFileName' => 'vendor/bin/typo3cms',
             'extensionKeys' => ['foo', 'bar']
         ];
-        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+
+        $mockTask = $this->getMockTaskForConsoleVersion('7.0.0');
+        $mockTask->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted("cd '{$this->deployment->getApplicationReleasePath($this->application)}'");
+        $this->assertCommandExecuted("php 'vendor/bin/typo3cms' 'extension:setup' '-e' 'foo' '-e' 'bar'");
+    }
+
+    /**
+     * @test
+     */
+    public function consoleIsFoundInCorrectPathWithoutAppDirectoryForOldConsoleVersion(): void
+    {
+        $options = [
+            'scriptFileName' => 'vendor/bin/typo3cms',
+            'extensionKeys' => ['foo', 'bar']
+        ];
+
+        $mockTask = $this->getMockTaskForConsoleVersion('6.9.9');
+        $mockTask->execute($this->node, $this->application, $this->deployment, $options);
         $this->assertCommandExecuted("cd '{$this->deployment->getApplicationReleasePath($this->application)}'");
         $this->assertCommandExecuted("php 'vendor/bin/typo3cms' 'extension:setup' 'foo,bar'");
     }
@@ -88,11 +129,77 @@ class SetUpExtensionsTaskTest extends BaseTaskTest
             'scriptFileName' => 'vendor/bin/typo3cms',
             'webDirectory' => '/web/',
         ];
-        $this->task->execute($this->node, $this->application, $this->deployment, $options);
+
+        $mockTask = $this->getMockTaskForConsoleVersion('7.0.0');
+        $mockTask->execute($this->node, $this->application, $this->deployment, $options);
+        $this->assertCommandExecuted("cd '{$this->deployment->getApplicationReleasePath($this->application)}'");
+        $this->assertCommandExecuted(
+            "test -f '{$this->deployment->getApplicationReleasePath($this->application)}/vendor/bin/typo3cms'"
+        );
+        $this->assertCommandExecuted("php 'vendor/bin/typo3cms' 'extension:setup' '-e' 'foo' '-e' 'bar'");
+    }
+
+    /**
+     * @test
+     */
+    public function consoleIsFoundInCorrectPathWithWebDirectoryAndSlashesAreTrimmedForOldConsoleVersion(): void
+    {
+        $options = [
+            'extensionKeys' => ['foo', 'bar'],
+            'scriptFileName' => 'vendor/bin/typo3cms',
+            'webDirectory' => '/web/',
+        ];
+
+        $mockTask = $this->getMockTaskForConsoleVersion('6.9.9');
+        $mockTask->execute($this->node, $this->application, $this->deployment, $options);
         $this->assertCommandExecuted("cd '{$this->deployment->getApplicationReleasePath($this->application)}'");
         $this->assertCommandExecuted(
             "test -f '{$this->deployment->getApplicationReleasePath($this->application)}/vendor/bin/typo3cms'"
         );
         $this->assertCommandExecuted("php 'vendor/bin/typo3cms' 'extension:setup' 'foo,bar'");
+    }
+
+    protected function getMockShell()
+    {
+        $commands = &$this->commands;
+        $mockShell = $this->getMockBuilder(\TYPO3\Surf\Domain\Service\ShellCommandService::class)->getMock();
+        $mockShell
+            ->expects($this->any())
+            ->method('execute')
+            ->will($this->returnCallback(function ($command) use (&$commands, &$responses) {
+                if (is_array($command)) {
+                    $commands['executed'] = array_merge($commands['executed'], $command);
+                } else {
+                    $commands['executed'][] = $command;
+                    if (isset($responses[$command])) {
+                        return $responses[$command];
+                    }
+                }
+                return '';
+            }));
+        $mockShell
+            ->expects(self::any())
+            ->method('executeOrSimulate')
+            ->will($this->returnCallback(function ($command) use (&$commands, &$responses) {
+                if (is_array($command)) {
+                    $commands['executed'] = array_merge($commands['executed'], $command);
+                } else {
+                    $commands['executed'][] = $command;
+                    if (isset($responses[$command])) {
+                        return $responses[$command];
+                    }
+                }
+                return '';
+            }));
+        return $mockShell;
+    }
+
+    protected function getMockTaskForConsoleVersion(string $consoleVersion)
+    {
+        $mockTask = $this->getMockBuilder(\TYPO3\Surf\Task\TYPO3\CMS\SetUpExtensionsTask::class)
+            ->setMethods(['getConsoleVersion'])->getMock();
+        $mockTask->expects($this->once())->method('getConsoleVersion')->willReturn($consoleVersion);
+        $mockTask->setShellCommandService($this->getMockShell());
+        return $mockTask;
     }
 }


### PR DESCRIPTION
Related: #450