### PR TITLE
[TASK] Create symlink targets if they do not exist yet

### DIFF
--- a/src/Task/Generic/CreateSymlinksTask.php
+++ b/src/Task/Generic/CreateSymlinksTask.php
@@ -54,7 +54,7 @@ class CreateSymlinksTask extends Task implements ShellCommandServiceAwareInterfa
 
         foreach ($options['symlinks'] as $linkPath => $sourcePath) {
             // creates empty directory if path does not exist
-            $commands[] = sprintf('mkdir -p %s', $sourcePath);
+            $commands[] = sprintf('test -e %s || mkdir -p %s', $sourcePath);
 
             $commands[] = sprintf('ln -s %s %s', $sourcePath, $linkPath);
         }

--- a/src/Task/Generic/CreateSymlinksTask.php
+++ b/src/Task/Generic/CreateSymlinksTask.php
@@ -54,7 +54,7 @@ class CreateSymlinksTask extends Task implements ShellCommandServiceAwareInterfa
 
         foreach ($options['symlinks'] as $linkPath => $sourcePath) {
             // creates empty directory if path does not exist
-            $commands[] = sprintf('test -e %s || mkdir -p %s', $sourcePath);
+            $commands[] = sprintf('test -e %s || mkdir -p %s', $sourcePath, $sourcePath);
 
             $commands[] = sprintf('ln -s %s %s', $sourcePath, $linkPath);
         }

--- a/src/Task/Generic/CreateSymlinksTask.php
+++ b/src/Task/Generic/CreateSymlinksTask.php
@@ -53,6 +53,9 @@ class CreateSymlinksTask extends Task implements ShellCommandServiceAwareInterfa
         ];
 
         foreach ($options['symlinks'] as $linkPath => $sourcePath) {
+            // creates empty directory if path does not exist
+            $commands[] = sprintf('mkdir -p %s', $sourcePath);
+
             $commands[] = sprintf('ln -s %s %s', $sourcePath, $linkPath);
         }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Quality-of-life improvement.


* **What is the current behavior?** (You can also link to an open issue here)
Using `symlinks`, Surf would set symlinks to non-existent targets when being used to configure shared directories.

* **What is the new behavior (if this is a feature change)?**
Targets are created as empty directories if the path does not exist yet.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
Trying to update the outdated Surf example code on https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/DeployTYPO3.html I found that adding symlinks for `./var/log`, ... are not well supported by `symlinkDataFolders` (multi-level symlinks would add shared folders in unexpected locations). 
`symlinks` looks like the better alternative.

The suggestion for TYPO3v10+ would be:
```
    ->addSymlinks(
        [
            'var/charset' => '../../../shared/Data/var/charset',
            'var/lock' => '../../../shared/Data/var/lock',
            'var/log' => '../../../shared/Data/var/log',
            'var/session' => '../../../shared/Data/var/session',
        ]
    )
```
Before recommending it I would like Surf to take care of the initial deployment without any necessary intervention. Currently it would be necessary to add the directories `...shared/Data/var/lock`, ... manually.