### PR TITLE
[BUGFIX] Don't override responses on setUp

### DIFF
--- a/tests/Unit/Task/BaseTaskTest.php
+++ b/tests/Unit/Task/BaseTaskTest.php
@@ -64,7 +64,6 @@ abstract class BaseTaskTest extends TestCase
     {
         $this->commands = ['executed' => []];
         $commands = &$this->commands;
-        $this->responses = [];
         $responses = &$this->responses;
 
         /** @var MockObject|ShellCommandService $shellCommandService */


### PR DESCRIPTION
To define the responses in extending tests, the property must not been set in setUp method

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
If an extending test sets the responses array it is overridden by the setUp method


* **What is the new behavior (if this is a feature change)?**
An extending task can set the responses of the executed commands-


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**: