### PR TITLE
[BUGFIX] Fix parameter type for escapeshellarg(port)

### DIFF
--- a/src/Task/Transfer/RsyncTask.php
+++ b/src/Task/Transfer/RsyncTask.php
@@ -52,7 +52,7 @@ class RsyncTask extends Task implements ShellCommandServiceAwareInterface
         $username = $node->hasOption('username') ? $node->getOption('username') . '@' : '';
         $hostname = $node->getHostname();
         $noPubkeyAuthentication = $node->hasOption('password') ? ' -o PubkeyAuthentication=no' : '';
-        $port = $node->hasOption('port') ? ' -p ' . escapeshellarg($node->getOption('port')) : '';
+        $port = $node->hasOption('port') ? ' -p ' . escapeshellarg((string)$node->getOption('port')) : '';
         $key = $node->hasOption('privateKeyFile') ? ' -i ' . escapeshellarg($node->getOption('privateKeyFile')) : '';
         $rshFlag = ($node->isLocalhost() ? '' : '--rsh="ssh' . $noPubkeyAuthentication . $port . $key . '" ');
 


### PR DESCRIPTION
escapeshellarg expects the parameter to be a string.

Relates: cd5a2593

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

RsyncTask fails in PHP 8.1 if a port has been set.

* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**: