### PR TITLE
[TASK] replace deprecated strftime()

### DIFF
--- a/src/Domain/Model/Deployment.php
+++ b/src/Domain/Model/Deployment.php
@@ -100,7 +100,7 @@ class Deployment implements LoggerAwareInterface, ContainerAwareInterface
         $this->name = $name;
         $this->status = DeploymentStatus::UNKNOWN();
 
-        $time = strftime('%Y%m%d%H%M%S', time());
+        $time = date('YmdHis', time());
 
         if ($time === false) {
             throw new UnexpectedValueException('Could not create valid releaseIdentifier');

--- a/tests/Unit/Domain/Model/Clock/SystemClockTest.php
+++ b/tests/Unit/Domain/Model/Clock/SystemClockTest.php
@@ -55,7 +55,7 @@ class SystemClockTest extends TestCase
     public function validFormatCanBeConvertedToTimestamp(): array
     {
         return [
-            ['YmdHis', strftime('%Y%m%d%H%M%S', 1535216980), 1535216980],
+            ['YmdHis', date('YmdHis', 1535216980), 1535216980],
         ];
     }
 

--- a/tests/Unit/Task/CleanupReleasesTaskTest.php
+++ b/tests/Unit/Task/CleanupReleasesTaskTest.php
@@ -141,7 +141,7 @@ class CleanupReleasesTaskTest extends BaseTaskTest
         $folderStructure['.'] = '.';
         foreach ($identifiers as $time) {
             $timestampForCurrentFolder = strtotime($time, $currentTime);
-            $folderName = strftime('%Y%m%d%H%M%S', $timestampForCurrentFolder);
+            $folderName = date('YmdHis', $timestampForCurrentFolder);
             $this->clockMock->createTimestampFromFormat('YmdHis', $folderName)->willReturn($timestampForCurrentFolder);
             $folderStructure[$folderName] = ['index.php'];
         }
@@ -154,7 +154,7 @@ class CleanupReleasesTaskTest extends BaseTaskTest
 
         $command = array_reduce(
             array_map(
-                static fn ($expectedFolderToBeRemoved) => strftime('%Y%m%d%H%M%S', strtotime($expectedFolderToBeRemoved, $currentTime)),
+                static fn ($expectedFolderToBeRemoved) => date('YmdHis', strtotime($expectedFolderToBeRemoved, $currentTime)),
                 $expectedFoldersToBeRemoved
             ),
             fn ($command, $folder): string => $command . sprintf(


### PR DESCRIPTION
strftime() was deprecated in PHP 8.1. It is replaced by the equivalent
date() call.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 Bug fix


* **What is the current behavior?** (You can also link to an open issue here)

Depending on the PHP error_reporting, this is reported as `PHP Deprecated: Function strftime() is deprecated in /var/www/html/build/deployment/vendor/typo3/surf/src/Domain/Model/Deployment.php on line 103`

* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**: