### PR TITLE
[BUGFIX] Make compatible with psr/log:^3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "monolog/monolog": "^2.9.1",
         "myclabs/php-enum": "^1.8",
         "neos/utility-files": "^7.3.10",
+        "psr/log": "^1.0 || ^2.0",
         "symfony/config": "^5.0 || ^6.0",
         "symfony/console": "^5.0 || ^6.0",
         "symfony/dependency-injection": "^5.0 || ^6.0",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)

Unfortunately, no tests have been added yet. And I'm a bit unsure about the best way to test it. I found out that all tests are run with a predefined composer.lock file and I don't know if that is intentional or not. I started another PR for it: #768

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Limit package "psr/log" to "^1.0 || ^2.0"

* **What is the current behavior?** (You can also link to an open issue here)

In dad4d152103425fb639545bb3fb6037db3a5a9d6, the package "monolog/monolog" was upgraded and the new version of "monolog/monolog" requires "psr/log":"^1.0 || ^2.0 || ^3.0" - But Surf ist not compatible with psr/log:^3

> PHP Fatal error:  Declaration of TYPO3\Surf\Domain\Service\ShellCommandService::setLogger(Psr\Log\LoggerInterface $logger) must be compatible with Psr\Log\LoggerAwareInterface::setLogger(Psr\Log\LoggerInterface $logger): void in /tmp/vendor/typo3/surf/src/Integration/LoggerAwareTrait.php on line 20

See also #760

* **What is the new behavior (if this is a feature change)?**

The new behavior is to only install psr/log in version 1 or 2

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, it doesn't.

* **Other information**:

I also tried to make Surf compatible with psr/log:^3 but I would have needed to change https://github.com/TYPO3/Surf/blob/master/src/Domain/Model/Deployment.php#LL288C29-L288C29 from

```php
    public function setLogger(LoggerInterface $logger): self
    {
        $this->logger = $logger;

        return $this;
    }
```

to

```php
    public function setLogger(LoggerInterface $logger): void
    {
        $this->logger = $logger;
    }
```

Which would have been a breaking change.