### PR TITLE
FEATURE: Check if bin/surf can be executed with different PHP versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,3 +42,24 @@ jobs:
           composer-options: "--no-interaction --no-suggest"
 
       - run: vendor/bin/phpunit
+
+  canBeExecuted:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['7.4', '8.0', '8.1', '8.2']
+
+    name: Can be executed with PHP ${{ matrix.php }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none # disable xdebug, pcov
+
+      - uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: "--no-interaction --no-suggest"
+
+      - run: bin/surf


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

An additional test in GitHub workflow

* **What is the current behavior?** (You can also link to an open issue here)

There currently is no test, if surf itsself can be executed after installing all composer packages.

* **What is the new behavior (if this is a feature change)?**

In an additinal job, all composer packages are installed and `bin/surf` is executed and must not fail. The test is done with multiple PHP versions.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

I think, multiple problems (#760 #770 #771) could have been detected earlier, if such a test would have been existed.