### PR TITLE
Allow extending Symfony DI in surf

### DIFF
--- a/bin/surf
+++ b/bin/surf
@@ -8,11 +8,8 @@
  * file that was distributed with this source code.
  */
 
+use Custom\MyExtension;
 use SelfUpdate\SelfUpdateCommand;
-use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use TYPO3\Surf\Cli\Symfony\ConsoleApplication;
 use TYPO3\Surf\Cli\Symfony\ConsoleKernel;
 
@@ -20,6 +17,22 @@ requireAutoloader();
 
 
 $kernel = new ConsoleKernel('prod');
+$vendorPackages = array_map(
+    fn($dir) => json_decode(file_get_contents($dir . '/composer/installed.json'), true)['packages'] ?? [], 
+    array_keys(\Composer\Autoload\ClassLoader::getRegisteredLoaders())
+);
+foreach ($vendorPackages as $packages) {
+    foreach ($packages as $package) {
+        if (
+            'typo3-surf-exstension' == $package['type']
+            && null !== ($extension = $package['extra']['typo3-surf']['extension'] ?? null)
+            && class_exists($extension)
+        ) {
+            $kernel->addExtension(new $extension());
+        }
+    }
+}
+
 $kernel->boot();
 $container = $kernel->getContainer();
 /** @var ConsoleApplication $application */

--- a/src/Cli/Symfony/ConsoleKernel.php
+++ b/src/Cli/Symfony/ConsoleKernel.php
@@ -129,7 +129,7 @@ final class ConsoleKernel
 
             foreach ($this->extensions as $extension) {
                 $container->registerExtension($extension);
-                
+
                 $container->loadFromExtension($extension->getAlias(), null);
             }
             $container->getCompilerPassConfig()->setMergePass(new MergeExtensionConfigurationPass());

--- a/src/Cli/Symfony/DependencyInjection/Extension.php
+++ b/src/Cli/Symfony/DependencyInjection/Extension.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of TYPO3 Surf.
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
 namespace TYPO3\Surf\Cli\Symfony\DependencyInjection;
 
 use BadMethodCallException;
@@ -62,7 +69,7 @@ abstract class Extension implements ExtensionInterface
 
         $instanceofClosure = &\Closure::bind(fn &() => $this->instanceof, $extensionLoader, $extensionLoader)();
 
-        (fn(ContainerConfigurator $configurator) => $this->loadExtension($configurator, $container))((new ContainerConfigurator(
+        (fn (ContainerConfigurator $configurator) => $this->loadExtension($configurator, $container))((new ContainerConfigurator(
             $container,
             $extensionLoader,
             $instanceofClosure,

--- a/src/Cli/Symfony/DependencyInjection/Extension.php
+++ b/src/Cli/Symfony/DependencyInjection/Extension.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\Surf\Cli\Symfony\DependencyInjection;
+
+use BadMethodCallException;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+abstract class Extension implements ExtensionInterface
+{
+    public function getXsdValidationBasePath()
+    {
+        return false;
+    }
+
+    public function getNamespace(): string
+    {
+        return 'http://example.org/schema/dic/' . $this->getAlias();
+    }
+
+    public function getAlias(): string
+    {
+        $className = static::class;
+        if (!str_ends_with($className, 'Extension')) {
+            throw new BadMethodCallException('This extension does not follow the naming convention; you must overwrite the getAlias() method.');
+        }
+        $classBaseName = substr(str_replace('\\', '', $className), 0, -9);
+
+        return Container::underscore($classBaseName);
+    }
+
+    public function loadExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
+    {
+        $services = $container->services();
+        $reflection = new \ReflectionClass($this);
+        $namespace = $reflection->getNamespaceName();
+        $services->defaults()
+            ->autowire()
+            ->autoconfigure()
+            ->public();
+
+        $services->load($namespace . '\\', '*');
+    }
+
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $reflection = new \ReflectionClass($this);
+        $file = $reflection->getFileName();
+        $dirname = dirname($file);
+        $fileName = basename($file);
+
+        $env = $container->getParameter('kernel.environment');
+
+        $extensionLoader = new PhpFileLoader($container, new FileLocator());
+        $extensionLoader->setCurrentDir($dirname);
+
+        $instanceofClosure = &\Closure::bind(fn &() => $this->instanceof, $extensionLoader, $extensionLoader)();
+
+        (fn(ContainerConfigurator $configurator) => $this->loadExtension($configurator, $container))((new ContainerConfigurator(
+            $container,
+            $extensionLoader,
+            $instanceofClosure,
+            $dirname,
+            $fileName,
+            $env
+        )));
+    }
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR add the feature to use the symfony DI in custom surf extensions.
I was not able to use the logger in my custom Task. So I decided to make surf extendable.
Just create a Extension which extends `TYPO3\Surf\Cli\Symfony\DependencyInjection\Extension`
create a composer package with the `"type": "typo3-surf-exstension"` and define the extension namespace at `extra.typo3-surf.extension`.

* **What is the current behavior?** (You can also link to an open issue here)
I cant use for example the logger in my custom task.


* **What is the new behavior (if this is a feature change)?**
The Symfony DI can get used, for example, in custom tasks.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**: